### PR TITLE
add playlist mode for automatic video navigation

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -52,4 +52,6 @@ class PlayerPreferences(
   val defaultVideoZoom = preferenceStore.getFloat("default_video_zoom", 0f)
 
   val includeSubtitlesInSnapshot = preferenceStore.getBoolean("include_subtitles_in_snapshot", false)
+
+  val playlistMode = preferenceStore.getBoolean("playlist_mode", false)
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -39,6 +39,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import app.marlboroadvance.mpvex.domain.media.model.Video
 import app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository
 import app.marlboroadvance.mpvex.preferences.BrowserPreferences
+import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.SortOrder
 import app.marlboroadvance.mpvex.preferences.VideoSortType
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
@@ -79,6 +80,7 @@ data class VideoListScreen(
     val coroutineScope = rememberCoroutineScope()
     val backstack = LocalBackStack.current
     val browserPreferences = koinInject<BrowserPreferences>()
+    val playerPreferences = koinInject<PlayerPreferences>()
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
 
     // ViewModel
@@ -91,6 +93,7 @@ data class VideoListScreen(
     val videosWithPlaybackInfo by viewModel.videosWithPlaybackInfo.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val recentlyPlayedFilePath by viewModel.recentlyPlayedFilePath.collectAsState()
+    val playlistMode by playerPreferences.playlistMode.collectAsState()
 
     // Sorting
     val videoSortType by browserPreferences.videoSortType.collectAsState()
@@ -232,7 +235,14 @@ data class VideoListScreen(
           if (selectionManager.isInSelectionMode) {
             selectionManager.toggle(video)
           } else {
-            MediaUtils.playFile(video, context)
+            coroutineScope.launch {
+              MediaUtils.playFileWithAutoPlaylist(
+                video = video,
+                context = context,
+                playlistModeEnabled = playlistMode,
+                launchSource = "video_list"
+              )
+            }
           }
         },
         onVideoLongClick = { video -> selectionManager.toggle(video) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -83,6 +83,20 @@ object PlayerPreferencesScreen : Screen {
             onValueChange = preferences.closeAfterReachingEndOfVideo::set,
             title = { Text(stringResource(id = R.string.pref_player_close_after_eof)) },
           )
+          val playlistMode by preferences.playlistMode.collectAsState()
+          SwitchPreference(
+            value = playlistMode,
+            onValueChange = preferences.playlistMode::set,
+            title = { Text(text = "Playlist Mode") },
+            summary = { 
+              Text(
+                text = if (playlistMode)
+                  "Automatically enable next/previous navigation for all videos in folder"
+                else
+                  "Play videos individually (select multiple for playlist)"
+              )
+            },
+          )
           val rememberBrightness by preferences.rememberBrightness.collectAsState()
           SwitchPreference(
             value = rememberBrightness,

--- a/app/src/main/java/app/marlboroadvance/mpvex/utils/media/MediaUtils.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/utils/media/MediaUtils.kt
@@ -6,10 +6,13 @@ import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import app.marlboroadvance.mpvex.BuildConfig
 import app.marlboroadvance.mpvex.domain.media.model.Video
+import app.marlboroadvance.mpvex.repository.VideoRepository
 import app.marlboroadvance.mpvex.ui.player.PlayerActivity
 import app.marlboroadvance.mpvex.utils.history.RecentlyPlayedOps
 import `is`.xyz.mpv.Utils
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Central entry point for video playback operations.
@@ -175,5 +178,45 @@ object MediaUtils {
         if (videos.size == 1) "Share video" else "Share ${videos.size} videos",
       ),
     )
+  }
+
+  /**
+   * Play a video with automatic playlist from directory if playlist mode is enabled.
+   *
+   * @param video Video to play
+   * @param context Android context
+   * @param playlistModeEnabled Whether playlist mode is enabled
+   * @param launchSource Analytics identifier
+   */
+  suspend fun playFileWithAutoPlaylist(
+    video: Video,
+    context: Context,
+    playlistModeEnabled: Boolean,
+    launchSource: String? = null,
+  ) {
+    if (playlistModeEnabled) {
+      // Get all videos from the same directory
+      val allVideosInFolder = withContext(Dispatchers.IO) {
+        VideoRepository.getVideosInFolder(context, video.bucketId)
+      }
+      
+      if (allVideosInFolder.size > 1) {
+        // Find the index of the current video
+        val currentIndex = allVideosInFolder.indexOfFirst { it.id == video.id }
+        
+        // Create playlist intent
+        val intent = Intent(Intent.ACTION_VIEW, video.uri)
+        intent.setClass(context, PlayerActivity::class.java)
+        intent.putExtra("internal_launch", true)
+        intent.putParcelableArrayListExtra("playlist", ArrayList(allVideosInFolder.map { it.uri }))
+        intent.putExtra("playlist_index", if (currentIndex >= 0) currentIndex else 0)
+        intent.putExtra("launch_source", launchSource ?: "auto_playlist")
+        context.startActivity(intent)
+        return
+      }
+    }
+    
+    // Fall back to normal single file playback
+    playFile(video, context, launchSource)
   }
 }


### PR DESCRIPTION
- Add playlistMode preference setting
- Add playFileWithAutoPlaylist() function to automatically load directory videos
- Add playlist mode toggle in Player Preferences UI
- Update VideoListScreen to use auto-playlist when enabled

When playlist mode is enabled, clicking any video automatically creates a playlist with all videos from the same folder, enabling next/previous navigation without manual selection.