### PR TITLE
feat: add preference to move seekbar to the bottom of the screen or above the layout buttons

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -54,4 +54,6 @@ class PlayerPreferences(
   val playlistMode = preferenceStore.getBoolean("playlist_mode", false)
 
   val useWavySeekbar = preferenceStore.getBoolean("use_wavy_seekbar", true)
+
+  val bottomSeekbar = preferenceStore.getBoolean("bottom_seekbar", true)
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalRippleConfiguration
@@ -304,6 +305,7 @@ fun PlayerControls(
         }
 
         val areSlidersShown = isBrightnessSliderShown || isVolumeSliderShown
+        val bottomSeekbar by playerPreferences.bottomSeekbar.collectAsState()
 
         AnimatedVisibility(
           isBrightnessSliderShown,
@@ -735,7 +737,11 @@ fun PlayerControls(
             },
           modifier =
             Modifier.constrainAs(seekbar) {
-              bottom.linkTo(parent.bottom, if (isPortrait) spacing.larger else spacing.small)
+              if (bottomSeekbar) {
+                bottom.linkTo(parent.bottom, if (isPortrait) spacing.larger else spacing.small)
+              } else {
+                bottom.linkTo(bottomRightControls.top, 0.dp)
+              }
               start.linkTo(parent.start, spacing.medium)
               end.linkTo(parent.end, spacing.medium)
             },
@@ -890,7 +896,11 @@ fun PlayerControls(
             },
           modifier =
             Modifier.constrainAs(bottomRightControls) {
-              bottom.linkTo(seekbar.top, spacing.small)
+              if (bottomSeekbar) {
+                bottom.linkTo(seekbar.top, spacing.small)
+              } else {
+                bottom.linkTo(parent.bottom, if (isPortrait) spacing.larger else spacing.small)
+              }
               if (isPortrait) {
                 start.linkTo(parent.start, spacing.medium)
                 end.linkTo(parent.end, spacing.medium)
@@ -957,7 +967,11 @@ fun PlayerControls(
             },
           modifier =
             Modifier.constrainAs(bottomLeftControls) {
-              bottom.linkTo(seekbar.top, spacing.small)
+              if (bottomSeekbar) {
+                bottom.linkTo(seekbar.top, spacing.small)
+              } else {
+                bottom.linkTo(parent.bottom, spacing.small)
+              }
               start.linkTo(parent.start, spacing.medium)
               width = Dimension.fillToConstraints
               end.linkTo(bottomRightControls.start, spacing.small)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
@@ -1,34 +1,31 @@
 package app.marlboroadvance.mpvex.ui.player.controls.components.sheets
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreTime
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import app.marlboroadvance.mpvex.R
-import app.marlboroadvance.mpvex.preferences.SubtitlesPreferences
-import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.ui.player.TrackNode
 import app.marlboroadvance.mpvex.ui.theme.spacing
 import kotlinx.collections.immutable.ImmutableList
-import org.koin.compose.koinInject
 
 @Composable
 fun SubtitlesSheet(
@@ -39,6 +36,7 @@ fun SubtitlesSheet(
   onOpenSubtitleDelay: () -> Unit,
   onRemoveSubtitle: (Int) -> Unit,
   onDismissRequest: () -> Unit,
+  onSelectSecondary: (Int) -> Unit = {},
   modifier: Modifier = Modifier,
 ) {
   GenericTracksSheet(
@@ -61,9 +59,11 @@ fun SubtitlesSheet(
     track = { track ->
       SubtitleTrackRow(
         title = getTrackTitle(track, tracks),
+        // Pass 1 for Primary, 2 for Secondary, null for None
         selected = track.mainSelection?.toInt() ?: -1,
         isExternal = track.external == true,
         onClick = { onSelect(track.id) },
+        onLongClick = { onSelectSecondary(track.id) },
         onRemove = { onRemoveSubtitle(track.id) },
       )
     },
@@ -71,34 +71,58 @@ fun SubtitlesSheet(
   )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SubtitleTrackRow(
   title: String,
   selected: Int,
   isExternal: Boolean,
   onClick: () -> Unit,
+  onLongClick: () -> Unit,
   onRemove: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  // Determine states based on encoded selection value
+  val isSelected = selected > -1
+  val isPrimary = selected == 1
+  val isSecondary = selected == 2
+
   Row(
     modifier =
       modifier
         .fillMaxWidth()
-        .clickable(onClick = onClick)
+        .combinedClickable(
+          onClick = onClick,
+          onLongClick = onLongClick
+        )
         .padding(horizontal = MaterialTheme.spacing.medium, vertical = MaterialTheme.spacing.extraSmall),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
   ) {
-    RadioButton(
-      selected = selected > -1,
-      onClick = onClick,
+    Checkbox(
+      checked = isSelected,
+      onCheckedChange = { onClick() },
     )
-    Text(
-      title,
-      fontStyle = if (selected > -1) FontStyle.Italic else FontStyle.Normal,
-      fontWeight = if (selected > -1) FontWeight.ExtraBold else FontWeight.Normal,
-      modifier = Modifier.weight(1f),
-    )
+
+    // CHANGE LOG: Added column to display track title and Primary/Secondary label
+    // Impact: Clearly indicates which subtitle is which, reducing confusion
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        title,
+        fontStyle = if (isSelected) FontStyle.Italic else FontStyle.Normal,
+        fontWeight = if (isSelected) FontWeight.ExtraBold else FontWeight.Normal,
+      )
+
+      if (isSelected) {
+        Text(
+          text = if (isPrimary) "Primary" else "Secondary",
+          style = MaterialTheme.typography.labelSmall,
+          color = if (isPrimary) MaterialTheme.colorScheme.primary
+          else MaterialTheme.colorScheme.secondary
+        )
+      }
+    }
+
     if (isExternal) {
       IconButton(onClick = onRemove) {
         Icon(Icons.Default.Delete, contentDescription = null)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/ControlLayoutPreview.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/ControlLayoutPreview.kt
@@ -43,6 +43,7 @@ fun ControlLayoutPreview(
   bottomRightButtons: List<PlayerButton>,
   bottomLeftButtons: List<PlayerButton>,
   portraitBottomButtons: List<PlayerButton>,
+  bottomSeekbar: Boolean = true,
   modifier: Modifier = Modifier,
 ) {
   Column(modifier = modifier) {
@@ -57,6 +58,7 @@ fun ControlLayoutPreview(
       topRightButtons = topRightButtons,
       bottomLeftButtons = bottomLeftButtons,
       bottomRightButtons = bottomRightButtons,
+      bottomSeekbar = bottomSeekbar,
     )
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -70,6 +72,7 @@ fun ControlLayoutPreview(
     PortraitPreview(
       topButtons = topLeftButtons, // Back + Title
       bottomButtons = portraitBottomButtons,
+      bottomSeekbar = bottomSeekbar,
     )
   }
 }
@@ -80,6 +83,7 @@ private fun LandscapePreview(
   topRightButtons: List<PlayerButton>,
   bottomLeftButtons: List<PlayerButton>,
   bottomRightButtons: List<PlayerButton>,
+  bottomSeekbar: Boolean,
 ) {
   Card(
     modifier = Modifier.fillMaxWidth(),
@@ -91,7 +95,7 @@ private fun LandscapePreview(
         Modifier
           .fillMaxWidth()
           .padding(12.dp)
-          .height(180.dp), // Slightly taller
+          .height(200.dp), // Increased height to prevent congestion
     ) {
       val (
         topLeft, topRight,
@@ -151,12 +155,70 @@ private fun LandscapePreview(
         PreviewIconButton(icon = Icons.Default.SkipNext, size = 28.dp)
       }
 
+      // --- SEEKBAR ---
+      LinearProgressIndicator(
+        progress = { 0.3f },
+        modifier =
+          Modifier.constrainAs(seekbar) {
+            if (bottomSeekbar) {
+              bottom.linkTo(parent.bottom)
+            } else {
+              bottom.linkTo(bottomRight.top, 8.dp)
+            }
+            start.linkTo(positionTime.end, 8.dp)
+            end.linkTo(durationTime.start, 8.dp)
+            if (bottomSeekbar) {
+              top.linkTo(positionTime.top)
+              bottom.linkTo(positionTime.bottom)
+            }
+            width = Dimension.fillToConstraints
+          },
+        color = Color.White,
+        trackColor = Color.Gray,
+      )
+
+      Text(
+        "1:23",
+        modifier =
+          Modifier.constrainAs(positionTime) {
+            start.linkTo(parent.start)
+            if (bottomSeekbar) {
+              bottom.linkTo(parent.bottom)
+            } else {
+              bottom.linkTo(seekbar.bottom)
+              top.linkTo(seekbar.top)
+            }
+          },
+        fontSize = 10.sp,
+        color = Color.White,
+      )
+      Text(
+        "4:56",
+        modifier =
+          Modifier.constrainAs(durationTime) {
+            end.linkTo(parent.end)
+            if (bottomSeekbar) {
+              bottom.linkTo(parent.bottom)
+            } else {
+              bottom.linkTo(seekbar.bottom)
+              top.linkTo(seekbar.top)
+            }
+          },
+        fontSize = 10.sp,
+        color = Color.White,
+      )
+
+
       // --- BOTTOM BAR (LEFT) ---
       FlowRow(
         modifier =
           Modifier.constrainAs(bottomLeft) {
             start.linkTo(parent.start)
-            bottom.linkTo(seekbar.top, 10.dp) // More spacing above seekbar
+            if (bottomSeekbar) {
+              bottom.linkTo(seekbar.top, 10.dp)
+            } else {
+              bottom.linkTo(parent.bottom)
+            }
             end.linkTo(bottomRight.start, 8.dp)
             width = Dimension.fillToConstraints
           },
@@ -173,7 +235,11 @@ private fun LandscapePreview(
         modifier =
           Modifier.constrainAs(bottomRight) {
             end.linkTo(parent.end)
-            bottom.linkTo(seekbar.top, 10.dp) // More spacing above seekbar
+            if (bottomSeekbar) {
+              bottom.linkTo(seekbar.top, 10.dp)
+            } else {
+              bottom.linkTo(parent.bottom)
+            }
             width = Dimension.preferredWrapContent
           },
         horizontalArrangement = Arrangement.spacedBy(2.dp), // extraSmall
@@ -183,41 +249,6 @@ private fun LandscapePreview(
           PreviewButton(button = button, size = 20.dp)
         }
       }
-
-      // --- SEEKBAR (Now at bottom) ---
-      Text(
-        "1:23",
-        modifier =
-          Modifier.constrainAs(positionTime) {
-            start.linkTo(parent.start)
-            bottom.linkTo(parent.bottom)
-          },
-        fontSize = 10.sp,
-        color = Color.White,
-      )
-      Text(
-        "4:56",
-        modifier =
-          Modifier.constrainAs(durationTime) {
-            end.linkTo(parent.end)
-            bottom.linkTo(parent.bottom)
-          },
-        fontSize = 10.sp,
-        color = Color.White,
-      )
-      LinearProgressIndicator(
-        progress = { 0.3f },
-        modifier =
-          Modifier.constrainAs(seekbar) {
-            start.linkTo(positionTime.end, 8.dp)
-            end.linkTo(durationTime.start, 8.dp)
-            bottom.linkTo(positionTime.bottom)
-            top.linkTo(positionTime.top)
-            width = Dimension.fillToConstraints
-          },
-        color = Color.White,
-        trackColor = Color.Gray,
-      )
     }
   }
 }
@@ -226,6 +257,7 @@ private fun LandscapePreview(
 private fun PortraitPreview(
   topButtons: List<PlayerButton>,
   bottomButtons: List<PlayerButton>,
+  bottomSeekbar: Boolean,
 ) {
   Card(
     modifier = Modifier.fillMaxWidth(),
@@ -281,6 +313,59 @@ private fun PortraitPreview(
         PreviewIconButton(icon = Icons.Default.SkipNext, size = 28.dp)
       }
 
+      // --- SEEKBAR ---
+      LinearProgressIndicator(
+        progress = { 0.3f },
+        modifier =
+          Modifier.constrainAs(seekbar) {
+            if (bottomSeekbar) {
+              bottom.linkTo(parent.bottom)
+            } else {
+              bottom.linkTo(bottomControls.top, 12.dp)
+            }
+            start.linkTo(positionTime.end, 8.dp)
+            end.linkTo(durationTime.start, 8.dp)
+            if (bottomSeekbar) {
+              top.linkTo(positionTime.top)
+              bottom.linkTo(positionTime.bottom)
+            }
+            width = Dimension.fillToConstraints
+          },
+        color = Color.White,
+        trackColor = Color.Gray,
+      )
+
+      Text(
+        "1:23",
+        modifier =
+          Modifier.constrainAs(positionTime) {
+            start.linkTo(parent.start)
+            if (bottomSeekbar) {
+              bottom.linkTo(parent.bottom)
+            } else {
+              bottom.linkTo(seekbar.bottom)
+              top.linkTo(seekbar.top)
+            }
+          },
+        fontSize = 10.sp,
+        color = Color.White,
+      )
+      Text(
+        "4:56",
+        modifier =
+          Modifier.constrainAs(durationTime) {
+            end.linkTo(parent.end)
+            if (bottomSeekbar) {
+              bottom.linkTo(parent.bottom)
+            } else {
+              bottom.linkTo(seekbar.bottom)
+              top.linkTo(seekbar.top)
+            }
+          },
+        fontSize = 10.sp,
+        color = Color.White,
+      )
+
       // --- BOTTOM BAR (Centered, Scrollable) ---
       Row(
         modifier =
@@ -288,7 +373,11 @@ private fun PortraitPreview(
             .constrainAs(bottomControls) {
               start.linkTo(parent.start)
               end.linkTo(parent.end)
-              bottom.linkTo(seekbar.top, 12.dp) // More spacing above seekbar
+              if (bottomSeekbar) {
+                bottom.linkTo(seekbar.top, 12.dp)
+              } else {
+                bottom.linkTo(parent.bottom)
+              }
               width = Dimension.fillToConstraints
             }
             .horizontalScroll(rememberScrollState()),
@@ -299,41 +388,6 @@ private fun PortraitPreview(
           PreviewButton(button = button, size = 22.dp) // Slightly larger (48dp scaled down)
         }
       }
-
-      // --- SEEKBAR (Now at bottom) ---
-      Text(
-        "1:23",
-        modifier =
-          Modifier.constrainAs(positionTime) {
-            start.linkTo(parent.start)
-            bottom.linkTo(parent.bottom)
-          },
-        fontSize = 10.sp,
-        color = Color.White,
-      )
-      Text(
-        "4:56",
-        modifier =
-          Modifier.constrainAs(durationTime) {
-            end.linkTo(parent.end)
-            bottom.linkTo(parent.bottom)
-          },
-        fontSize = 10.sp,
-        color = Color.White,
-      )
-      LinearProgressIndicator(
-        progress = { 0.3f },
-        modifier =
-          Modifier.constrainAs(seekbar) {
-            start.linkTo(positionTime.end, 8.dp)
-            end.linkTo(durationTime.start, 8.dp)
-            bottom.linkTo(positionTime.bottom)
-            top.linkTo(positionTime.top)
-            width = Dimension.fillToConstraints
-          },
-        color = Color.White,
-        trackColor = Color.Gray,
-      )
     }
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
@@ -67,6 +67,9 @@ object PlayerControlsPreferencesScreen : Screen {
     val bottomLState by appearancePrefs.bottomLeftControls.collectAsState()
     val portraitBottomState by appearancePrefs.portraitBottomControls.collectAsState()
 
+    // Collect the bottom seekbar preference state
+    val bottomSeekbar by playerPrefs.bottomSeekbar.collectAsState()
+
     var showResetDialog by remember { mutableStateOf(false) }
 
     if (showResetDialog) {
@@ -185,6 +188,7 @@ object PlayerControlsPreferencesScreen : Screen {
               bottomRightButtons = bottomRightButtons,
               bottomLeftButtons = bottomLeftButtons,
               portraitBottomButtons = portraitBottomButtons,
+              bottomSeekbar = bottomSeekbar, // Pass the collected state here
             )
           }
         }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -88,7 +88,7 @@ object PlayerPreferencesScreen : Screen {
             value = playlistMode,
             onValueChange = preferences.playlistMode::set,
             title = { Text(text = "Playlist Mode") },
-            summary = { 
+            summary = {
               Text(
                 text = if (playlistMode)
                   "Automatically enable next/previous navigation for all videos in folder"
@@ -105,6 +105,13 @@ object PlayerPreferencesScreen : Screen {
           )
           PreferenceCategory(
             title = { Text(stringResource(R.string.pref_player_seeking_title)) },
+          )
+          val bottomSeekbar by preferences.bottomSeekbar.collectAsState()
+          SwitchPreference(
+            value = bottomSeekbar,
+            onValueChange = preferences.bottomSeekbar::set,
+            title = { Text("Bottom seekbar") },
+            summary = { Text("Move seekbar to the bottom of the screen") },
           )
           val horizontalSeekGesture by preferences.horizontalSeekGesture.collectAsState()
           SwitchPreference(


### PR DESCRIPTION
This commit introduces a new preference in the player settings that allows users to toggle the position of the seekbar.

When enabled (default), the seekbar is located at the very bottom of the screen. When disabled, it is positioned above the bottom control buttons.

The changes include:
- Adding a `bottom_seekbar` boolean preference, defaulting to true.
- Integrating a "Bottom seekbar" switch into the player preferences screen.
- Updating the `PlayerControls` layout to dynamically adjust the seekbar's position based on this preference.
- Modifying the `ControlLayoutPreview` to accurately reflect the new seekbar position option.