### PR TITLE
Add grid mode with adjustable columns for folders and videos

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/AdvancedPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/AdvancedPreferences.kt
@@ -18,4 +18,5 @@ class AdvancedPreferences(
 
   val enableLuaScripts = preferenceStore.getBoolean("enable_lua_scripts", false)
   val selectedLuaScripts = preferenceStore.getStringSet("selected_lua_scripts", emptySet())
+
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/BrowserPreferences.kt
@@ -19,11 +19,17 @@ class BrowserPreferences(
 
   val folderViewMode = preferenceStore.getEnum("folder_view_mode", FolderViewMode.AlbumView)
 
+
+  val folderGridColumns = preferenceStore.getInt("folder_grid_columns", 3)
+  val videoGridColumns = preferenceStore.getInt("video_grid_columns", 2)
+
   // Visibility preferences for video card chips
   val showSizeChip = preferenceStore.getBoolean("show_size_chip", true)
   val showResolutionChip = preferenceStore.getBoolean("show_resolution_chip", true)
   val showFramerateInResolution = preferenceStore.getBoolean("show_framerate_in_resolution", true)
   val showProgressBar = preferenceStore.getBoolean("show_progress_bar", true)
+
+  val mediaLayoutMode = preferenceStore.getEnum("media_layout_mode", MediaLayoutMode. LIST)
 
   // Visibility preferences for folder card chips
   val showTotalVideosChip = preferenceStore.getBoolean("show_total_videos_chip", true)
@@ -101,4 +107,16 @@ enum class FolderViewMode {
         AlbumView -> "Folder View"
         FileManager -> "Tree View"
       }
+}
+
+enum class MediaLayoutMode {
+  LIST,
+  GRID,
+  ;
+
+  val displayName:  String
+    get() = when (this) {
+      LIST -> "List"
+      GRID -> "Grid"
+    }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/FolderCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/FolderCard.kt
@@ -48,6 +48,7 @@ fun FolderCard(
   customIcon: androidx.compose.ui.graphics.vector.ImageVector? = null,
   newVideoCount: Int = 0,
   customChipContent: @Composable (() -> Unit)? = null,
+  isGridMode: Boolean = false,
 ) {
   val appearancePreferences = koinInject<AppearancePreferences>()
   val browserPreferences = koinInject<BrowserPreferences>()
@@ -62,92 +63,161 @@ fun FolderCard(
   val parentPath = folder.path.substringBeforeLast("/", folder.path)
 
   Card(
-    modifier =
-      modifier
-        .fillMaxWidth()
-        .debouncedCombinedClickable(
-          onClick = onClick,
-          onLongClick = onLongClick,
-        ),
-    colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+    modifier = modifier
+      .fillMaxWidth()
+      . debouncedCombinedClickable(
+        onClick = onClick,
+        onLongClick = onLongClick,
+      ),
+    colors = CardDefaults. cardColors(containerColor = Color. Transparent),
   ) {
-    Row(
-      modifier =
-        Modifier
-          .fillMaxWidth()
+    if (isGridMode) {
+      // GRID LAYOUT - Vertical arrangement
+      Column(
+        modifier = Modifier
+          . fillMaxWidth()
           .background(
-            if (isSelected) MaterialTheme.colorScheme.tertiary.copy(alpha = 0.3f) else Color.Transparent,
+            if (isSelected) MaterialTheme.colorScheme.tertiary. copy(alpha = 0.3f) else Color.Transparent,
           )
-          .padding(16.dp),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      Box(
-        modifier =
-          Modifier
-            .size(64.dp)
+          .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Box(
+          modifier = Modifier
+            . size(72.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .debouncedCombinedClickable(
+            . debouncedCombinedClickable(
               onClick = onThumbClick,
               onLongClick = onLongClick,
             ),
-        contentAlignment = Alignment.Center,
-      ) {
-        Icon(
-          customIcon ?: Icons.Filled.Folder,
-          contentDescription = "Folder",
-          modifier = Modifier.size(48.dp),
-          tint = MaterialTheme.colorScheme.secondary,
-        )
+          contentAlignment = Alignment.Center,
+        ) {
+          Icon(
+            customIcon ?: Icons.Filled.Folder,
+            contentDescription = "Folder",
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.secondary,
+          )
 
-        // Show new video count badge if folder contains new videos
-        if (newVideoCount > 0) {
-          Box(
-            modifier =
-              Modifier
-                .align(Alignment.TopEnd)
-                .padding(4.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(Color(0xFFD32F2F)) // Warning red color
-                .padding(horizontal = 6.dp, vertical = 2.dp),
-          ) {
-            Text(
-              text = newVideoCount.toString(),
-              style = MaterialTheme.typography.labelSmall.copy(
-                fontWeight = FontWeight.Bold,
-              ),
-              color = Color.White,
-            )
+          // Show new video count badge if folder contains new videos
+          if (newVideoCount > 0) {
+            Box(
+              modifier =
+                Modifier
+                  .align(Alignment.TopEnd)
+                  .padding(4.dp)
+                  .clip(RoundedCornerShape(4.dp))
+                  .background(Color(0xFFD32F2F)) // Warning red color
+                  .padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+              Text(
+                text = newVideoCount.toString(),
+                style = MaterialTheme.typography.labelSmall.copy(
+                  fontWeight = FontWeight.Bold,
+                ),
+                color = Color.White,
+              )
+            }
           }
         }
-      }
-      Spacer(modifier = Modifier.width(16.dp))
-      Column(
-        modifier = Modifier.weight(1f),
-      ) {
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         Text(
           folder.name,
-          style = MaterialTheme.typography.titleMedium,
+          style = MaterialTheme.typography.titleSmall,
           color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
-          maxLines = maxLines,
-          overflow = TextOverflow.Ellipsis,
+          maxLines = 2,
+          overflow = TextOverflow. Ellipsis,
+          textAlign = androidx.compose.ui. text.style.TextAlign.Center,
         )
-        if (showFolderPath && parentPath.isNotEmpty()) {
+
+        if (showTotalVideosChip && folder.videoCount > 0) {
           Text(
-            parentPath,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            if (folder.videoCount == 1) "1 Video" else "${folder.videoCount} Videos",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme. onSurfaceVariant,
+          )
+        }
+      }
+    } else {
+      Row(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .background(
+              if (isSelected) MaterialTheme.colorScheme.tertiary.copy(alpha = 0.3f) else Color.Transparent,
+            )
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Box(
+          modifier =
+            Modifier
+              .size(64.dp)
+              .clip(RoundedCornerShape(12.dp))
+              .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+              .debouncedCombinedClickable(
+                onClick = onThumbClick,
+                onLongClick = onLongClick,
+              ),
+          contentAlignment = Alignment.Center,
+        ) {
+          Icon(
+            customIcon ?: Icons.Filled.Folder,
+            contentDescription = "Folder",
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.secondary,
+          )
+
+        // Show new video count badge if folder contains new videos
+          if (newVideoCount > 0) {
+            Box(
+              modifier =
+                Modifier
+                  .align(Alignment.TopEnd)
+                  .padding(4.dp)
+                  .clip(RoundedCornerShape(4.dp))
+                  .background(Color(0xFFD32F2F)) // Warning red color
+                  .padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+              Text(
+              	text = newVideoCount.toString(),
+                style = MaterialTheme.typography.labelSmall.copy(
+                  fontWeight = FontWeight.Bold,
+                ),
+                color = Color.White,
+              )
+            }
+          }
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(
+          modifier = Modifier.weight(1f),
+        ) {
+          Text(
+            folder.name,
+            style = MaterialTheme.typography.titleMedium,
+            color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
             maxLines = maxLines,
             overflow = TextOverflow.Ellipsis,
           )
-          Spacer(modifier = Modifier.height(4.dp))
-        } else {
-          Spacer(modifier = Modifier.height(4.dp))
-        }
-        Row {
-          // Render custom chip content first if provided
-          var hasChip = false
-          
+          if (showFolderPath && parentPath.isNotEmpty()) {
+            Text(
+              parentPath,
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              maxLines = maxLines,
+              overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+          } else {
+            Spacer(modifier = Modifier.height(4.dp))
+          }
+          Row {
+            // Render custom chip content first if provided
+            var hasChip = false
           if (customChipContent != null) {
             customChipContent()
             hasChip = true
@@ -155,76 +225,77 @@ fun FolderCard(
           }
           
           // Hide chips at storage root level (when videoCount is 0)
-          if (showTotalVideosChip && folder.videoCount > 0) {
-            Text(
-              if (folder.videoCount == 1) "1 Video" else "${folder.videoCount} Videos",
-              style = MaterialTheme.typography.labelSmall,
-              modifier =
-                Modifier
-                  .background(
-                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                    RoundedCornerShape(8.dp),
-                  )
-                  .padding(horizontal = 8.dp, vertical = 4.dp),
-              color = MaterialTheme.colorScheme.onSurface,
-            )
-            hasChip = true
-          }
-
-          if (showTotalSizeChip && folder.totalSize > 0) {
-            if (hasChip) {
-              Spacer(modifier = Modifier.width(4.dp))
+            if (showTotalVideosChip && folder.videoCount > 0) {
+              Text(
+                if (folder.videoCount == 1) "1 Video" else "${folder.videoCount} Videos",
+                style = MaterialTheme.typography.labelSmall,
+                modifier =
+                  Modifier
+                    .background(
+                      MaterialTheme.colorScheme.surfaceContainerHigh,
+                      RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+              hasChip = true
             }
-            Text(
-              formatFileSize(folder.totalSize),
-              style = MaterialTheme.typography.labelSmall,
-              modifier =
-                Modifier
-                  .background(
-                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                    RoundedCornerShape(8.dp),
-                  )
-                  .padding(horizontal = 8.dp, vertical = 4.dp),
-              color = MaterialTheme.colorScheme.onSurface,
-            )
-            hasChip = true
-          }
 
-          if (showTotalDurationChip && folder.totalDuration > 0) {
-            if (hasChip) {
-              Spacer(modifier = Modifier.width(4.dp))
+            if (showTotalSizeChip && folder.totalSize > 0) {
+              if (hasChip) {
+                Spacer(modifier = Modifier.width(4.dp))
+              }
+              Text(
+                formatFileSize(folder.totalSize),
+                style = MaterialTheme.typography.labelSmall,
+                modifier =
+                  Modifier
+                    .background(
+                      MaterialTheme.colorScheme.surfaceContainerHigh,
+                      RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+              hasChip = true
             }
-            Text(
-              formatDuration(folder.totalDuration),
-              style = MaterialTheme.typography.labelSmall,
-              modifier =
-                Modifier
-                  .background(
-                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                    RoundedCornerShape(8.dp),
-                  )
-                  .padding(horizontal = 8.dp, vertical = 4.dp),
-              color = MaterialTheme.colorScheme.onSurface,
-            )
-            hasChip = true
-          }
 
-          if (showDateModified && folder.lastModified > 0) {
-            if (hasChip) {
-              Spacer(modifier = Modifier.width(4.dp))
+            if (showTotalDurationChip && folder.totalDuration > 0) {
+              if (hasChip) {
+                Spacer(modifier = Modifier.width(4.dp))
+              }
+              Text(
+                formatDuration(folder.totalDuration),
+                style = MaterialTheme.typography.labelSmall,
+                modifier =
+                  Modifier
+                    .background(
+                      MaterialTheme.colorScheme.surfaceContainerHigh,
+                      RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+              hasChip = true
             }
-            Text(
-              formatDate(folder.lastModified),
-              style = MaterialTheme.typography.labelSmall,
-              modifier =
-                Modifier
-                  .background(
-                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                    RoundedCornerShape(8.dp),
-                  )
-                  .padding(horizontal = 8.dp, vertical = 4.dp),
-              color = MaterialTheme.colorScheme.onSurface,
-            )
+
+            if (showDateModified && folder.lastModified > 0) {
+              if (hasChip) {
+                Spacer(modifier = Modifier.width(4.dp))
+              }
+              Text(
+                formatDate(folder.lastModified),
+                style = MaterialTheme.typography.labelSmall,
+                modifier =
+                  Modifier
+                    .background(
+                      MaterialTheme.colorScheme.surfaceContainerHigh,
+                      RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+            }
           }
         }
       }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/VideoCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.style.TextAlign
 import app.marlboroadvance.mpvex.R
 import app.marlboroadvance.mpvex.domain.media.model.Video
 import app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository
@@ -61,6 +62,8 @@ fun VideoCard(
   progressPercentage: Float? = null,
   isOldAndUnplayed: Boolean = false,
   onThumbClick: () -> Unit = {},
+  isGridMode: Boolean = false,
+  gridColumns: Int = 1,
 ) {
   val appearancePreferences = koinInject<AppearancePreferences>()
   val browserPreferences = koinInject<BrowserPreferences>()
@@ -74,62 +77,57 @@ fun VideoCard(
   val maxLines = if (unlimitedNameLines) Int.MAX_VALUE else 2
 
   Card(
-    modifier =
-      modifier
-        .fillMaxWidth()
-        .debouncedCombinedClickable(
-          onClick = onClick,
-          onLongClick = onLongClick,
-        ),
-    colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+    modifier = modifier
+      .then(
+        if (isGridMode) Modifier.fillMaxWidth() else Modifier.fillMaxWidth()
+      )
+      . debouncedCombinedClickable(
+        onClick = onClick,
+        onLongClick = onLongClick,
+      ),
+    colors = CardDefaults. cardColors(containerColor = Color. Transparent),
   ) {
-    Row(
-      modifier =
-        Modifier
-          .fillMaxWidth()
+    if (isGridMode) {
+      // GRID LAYOUT - Vertical arrangement
+      Column(
+        modifier = Modifier
+          . fillMaxWidth()
           .background(
             if (isSelected) {
-              MaterialTheme.colorScheme.tertiary.copy(alpha = 0.3f)
+              MaterialTheme.colorScheme.tertiary. copy(alpha = 0.3f)
             } else {
-              Color.Transparent
+              Color. Transparent
             },
           )
-          .padding(12.dp),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      val thumbnailRepository = koinInject<ThumbnailRepository>()
-      // Rectangular thumbnail (16:9) with fixed width; height derives from aspect ratio
-      val thumbWidthDp = 128.dp
-      val aspect = 16f / 9f
-      val thumbWidthPx = with(LocalDensity.current) { thumbWidthDp.roundToPx() }
-      val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+          .padding(8.dp),
+        horizontalAlignment = if (gridColumns == 1) Alignment.Start else Alignment.CenterHorizontally,
+      ) {
+        val thumbnailRepository = koinInject<ThumbnailRepository>()
+        val thumbWidthDp = 160.dp
+        val aspect = 16f / 9f
+        val thumbWidthPx = with(LocalDensity.current) { thumbWidthDp.roundToPx() }
+        val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
 
-      // Load thumbnail with optimized state management
-      // Key includes video identity to prevent reloading same thumbnail
-      val thumbnailKey =
-        remember(video.id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx) {
+        val thumbnailKey = remember(video. id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx) {
           "${video.id}_${video.dateModified}_${video.size}_${thumbWidthPx}_$thumbHeightPx"
         }
 
-      // Try to get from memory cache immediately (synchronous, no flicker)
-      var thumbnail by remember(thumbnailKey) {
-        mutableStateOf(thumbnailRepository.getThumbnailFromMemory(video, thumbWidthPx, thumbHeightPx))
-      }
-
-      // Only load if not already in memory - prevents reload on recomposition
-      LaunchedEffect(thumbnailKey) {
-        if (thumbnail == null) {
-          thumbnail =
-            withContext(Dispatchers.IO) {
-              thumbnailRepository.getThumbnail(video, thumbWidthPx, thumbHeightPx)
-            }
+        var thumbnail by remember(thumbnailKey) {
+          mutableStateOf(thumbnailRepository.getThumbnailFromMemory(video, thumbWidthPx, thumbHeightPx))
         }
-      }
 
-      Box(
-        modifier =
-          Modifier
-            .width(thumbWidthDp)
+        LaunchedEffect(thumbnailKey) {
+          if (thumbnail == null) {
+            thumbnail = withContext(Dispatchers.IO) {
+              thumbnailRepository. getThumbnail(video, thumbWidthPx, thumbHeightPx)
+            }
+          }
+        }
+
+        // Thumbnail
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
             .aspectRatio(aspect)
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
@@ -137,149 +135,309 @@ fun VideoCard(
               onClick = onThumbClick,
               onLongClick = onLongClick,
             ),
-        contentAlignment = Alignment.Center,
-      ) {
-        thumbnail?.let {
-          Image(
-            bitmap = it.asImageBitmap(),
-            contentDescription = "Thumbnail",
-            modifier = Modifier.matchParentSize(),
-            contentScale = ContentScale.Crop,
-          )
-        } ?: run {
-          Icon(
-            Icons.Filled.PlayArrow,
-            contentDescription = "Play",
-            modifier = Modifier.size(48.dp),
-            tint = MaterialTheme.colorScheme.secondary,
-          )
-        }
+          contentAlignment = Alignment.Center,
+        ) {
+          thumbnail?. let {
+            Image(
+              bitmap = it.asImageBitmap(),
+              contentDescription = "Thumbnail",
+              modifier = Modifier. matchParentSize(),
+              contentScale = ContentScale. Crop,
+            )
+          } ?: run {
+            Icon(
+              Icons. Filled.PlayArrow,
+              contentDescription = "Play",
+              modifier = Modifier.size(48.dp),
+              tint = MaterialTheme.colorScheme.secondary,
+            )
+          }
 
-        // Show "NEW" label for recently added unplayed videos if enabled (top-left corner)
-        // Like MX Player: show NEW for videos added within threshold days that haven't been played
-        if (showUnplayedOldVideoLabel && isOldAndUnplayed) {
-          // Check if video is recently added (within threshold days)
-          val currentTime = System.currentTimeMillis()
-          val videoAge = currentTime - (video.dateAdded * 1000) // dateAdded is in seconds
-          val thresholdMillis = unplayedOldVideoDays * 24 * 60 * 60 * 1000L
+          // Duration overlay
+          Box(
+            modifier = Modifier
+              .align(Alignment. BottomEnd)
+              .padding(6.dp)
+              .clip(RoundedCornerShape(4.dp))
+              .background(Color.Black.copy(alpha = 0.65f))
+              .padding(horizontal = 6.dp, vertical = 2.dp),
+          ) {
+            Text(
+              text = video. durationFormatted,
+              style = MaterialTheme.typography. labelSmall,
+              color = Color.White,
+            )
+          }
 
-          if (videoAge <= thresholdMillis) {
+          // Progress bar
+          if (progressPercentage != null && showProgressBar) {
             Box(
-              modifier =
-                Modifier
-                  .align(Alignment.TopStart)
-                  .padding(6.dp)
-                  .clip(RoundedCornerShape(4.dp))
-                  .background(Color(0xFFD32F2F)) // Warning red color
-                  .padding(horizontal = 8.dp, vertical = 3.dp),
+              modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(4.dp),
             ) {
-              Text(
-                text = stringResource(R.string.video_label_new),
-                style = MaterialTheme.typography.labelSmall.copy(
-                  fontWeight = FontWeight.Bold,
-                ),
-                color = Color.White,
+              Box(modifier = Modifier.matchParentSize().background(Color.Black. copy(alpha = 0.6f)))
+              Box(
+                modifier = Modifier
+                  .fillMaxHeight()
+                  . fillMaxWidth(progressPercentage)
+                  .background(MaterialTheme.colorScheme.primary),
               )
             }
           }
         }
 
-        // Duration timestamp overlay at bottom-right of the thumbnail
-        Box(
-          modifier =
-            Modifier
-              .align(Alignment.BottomEnd)
-              .padding(6.dp)
-              .clip(RoundedCornerShape(4.dp))
-              .background(Color.Black.copy(alpha = 0.65f))
-              .padding(horizontal = 6.dp, vertical = 2.dp),
-        ) {
-          Text(
-            text = video.durationFormatted,
-            style = MaterialTheme.typography.labelSmall,
-            color = Color.White,
-          )
-        }
+        Spacer(modifier = Modifier.height(8.dp))
 
-        // Progress bar at bottom of thumbnail
-        if (progressPercentage != null && showProgressBar) {
-          Box(
-            modifier =
-              Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .height(4.dp),
-          ) {
-            // Background (unwatched portion)
-            Box(
-              modifier =
-                Modifier
-                  .matchParentSize()
-                  .background(Color.Black.copy(alpha = 0.6f)),
-            )
-            // Progress (watched portion)
-            Box(
-              modifier =
-                Modifier
-                  .fillMaxHeight()
-                  .fillMaxWidth(progressPercentage)
-                  .background(MaterialTheme.colorScheme.primary),
-            )
+        // Title below thumbnail
+        Text(
+          text = video.displayName,
+          style = if (gridColumns == 1) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleSmall,
+          color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
+          maxLines = 2,
+          overflow = TextOverflow. Ellipsis,
+          textAlign = if (gridColumns == 1) TextAlign.Start else TextAlign.Center,
+        )
+        if (gridColumns == 1) {
+          Spacer(modifier = Modifier.height(4.dp))
+          Row {
+            if (showSizeChip && video.sizeFormatted != "0 B" && video.sizeFormatted != "--") {
+              Text(
+                video.sizeFormatted,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                  .background(
+                    MaterialTheme.colorScheme.surfaceContainerHigh,
+                    RoundedCornerShape(8.dp),
+                  )
+                  .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+            }
+            if (showResolutionChip && video.resolution != "--") {
+              if (showSizeChip && video.sizeFormatted != "0 B" && video.sizeFormatted != "--") {
+                Spacer(modifier = Modifier.width(4.dp))
+              }
+              val displayResolution = if (showFramerateInResolution) {
+                video.resolution
+              } else {
+                video.resolution.substringBefore("@")
+              }
+              Text(
+                displayResolution,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                  .background(
+                    MaterialTheme.colorScheme.surfaceContainerHigh,
+                    RoundedCornerShape(8.dp),
+                  )
+                  .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+            }
           }
         }
       }
-      Spacer(modifier = Modifier.width(16.dp))
-      Column(
-        modifier = Modifier.weight(1f),
+    } else {
+      Row(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .background(
+              if (isSelected) {
+                MaterialTheme.colorScheme.tertiary.copy(alpha = 0.3f)
+              } else {
+                Color.Transparent
+              },
+            )
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
       ) {
-        Text(
-          video.displayName,
-          style = MaterialTheme.typography.titleSmall,
-          color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
-          maxLines = maxLines,
-          overflow = TextOverflow.Ellipsis,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Row {
-          if (showSizeChip && video.sizeFormatted != "0 B" && video.sizeFormatted != "--") {
-            Text(
-              video.sizeFormatted,
-              style = MaterialTheme.typography.labelSmall,
-              modifier =
-                Modifier
-                  .background(
-                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                    RoundedCornerShape(8.dp),
-                  )
-                  .padding(horizontal = 8.dp, vertical = 4.dp),
-              color = MaterialTheme.colorScheme.onSurface,
+        val thumbnailRepository = koinInject<ThumbnailRepository>()
+        // Rectangular thumbnail (16:9) with fixed width; height derives from aspect ratio
+        val thumbWidthDp = 128.dp
+        val aspect = 16f / 9f
+        val thumbWidthPx = with(LocalDensity.current) { thumbWidthDp.roundToPx() }
+        val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+
+        // Load thumbnail with optimized state management
+        // Key includes video identity to prevent reloading same thumbnail
+        val thumbnailKey =
+          remember(video.id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx) {
+            "${video.id}_${video.dateModified}_${video.size}_${thumbWidthPx}_$thumbHeightPx"
+          }
+
+        // Try to get from memory cache immediately (synchronous, no flicker)
+        var thumbnail by remember(thumbnailKey) {
+          mutableStateOf(thumbnailRepository.getThumbnailFromMemory(video, thumbWidthPx, thumbHeightPx))
+        }
+
+        // Only load if not already in memory - prevents reload on recomposition
+        LaunchedEffect(thumbnailKey) {
+          if (thumbnail == null) {
+            thumbnail =
+              withContext(Dispatchers.IO) {
+                thumbnailRepository.getThumbnail(video, thumbWidthPx, thumbHeightPx)
+              }
+          }
+        }
+
+        Box(
+          modifier =
+            Modifier
+              .width(thumbWidthDp)
+              .aspectRatio(aspect)
+              .clip(RoundedCornerShape(12.dp))
+              .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+              .debouncedCombinedClickable(
+                onClick = onThumbClick,
+                onLongClick = onLongClick,
+              ),
+          contentAlignment = Alignment.Center,
+        ) {
+          thumbnail?.let {
+            Image(
+              bitmap = it.asImageBitmap(),
+              contentDescription = "Thumbnail",
+              modifier = Modifier.matchParentSize(),
+              contentScale = ContentScale.Crop,
+            )
+          } ?: run {
+            Icon(
+              Icons.Filled.PlayArrow,
+              contentDescription = "Play",
+              modifier = Modifier.size(48.dp),
+              tint = MaterialTheme.colorScheme.secondary,
             )
           }
-          if (showResolutionChip && video.resolution != "--") {
-            if (showSizeChip && video.sizeFormatted != "0 B" && video.sizeFormatted != "--") {
-              Spacer(modifier = Modifier.width(4.dp))
-            }
 
-            // Extract base resolution without FPS for display
-            val displayResolution = if (showFramerateInResolution) {
-              video.resolution
-            } else {
-              // Remove @fps part if present
-              video.resolution.substringBefore("@")
-            }
+          // Show "NEW" label for recently added unplayed videos if enabled (top-left corner)
+          // Like MX Player: show NEW for videos added within threshold days that haven't been played
+          if (showUnplayedOldVideoLabel && isOldAndUnplayed) {
+            // Check if video is recently added (within threshold days)
+            val currentTime = System.currentTimeMillis()
+            val videoAge = currentTime - (video.dateAdded * 1000) // dateAdded is in seconds
+            val thresholdMillis = unplayedOldVideoDays * 24 * 60 * 60 * 1000L
 
+            if (videoAge <= thresholdMillis) {
+              Box(
+                modifier =
+                  Modifier
+                    .align(Alignment.TopStart)
+                    .padding(6.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(Color(0xFFD32F2F)) // Warning red color
+                    .padding(horizontal = 8.dp, vertical = 3.dp),
+              ) {
+                Text(
+                  text = stringResource(R.string.video_label_new),
+                  style = MaterialTheme.typography.labelSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                  ),
+                  color = Color.White,
+                )
+              }
+            }
+          }
+
+          // Duration timestamp overlay at bottom-right of the thumbnail
+          Box(
+            modifier =
+              Modifier
+                .align(Alignment.BottomEnd)
+                .padding(6.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(Color.Black.copy(alpha = 0.65f))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+          ) {
             Text(
-              displayResolution,
+              text = video.durationFormatted,
               style = MaterialTheme.typography.labelSmall,
+              color = Color.White,
+            )
+          }
+
+          // Progress bar at bottom of thumbnail
+          if (progressPercentage != null && showProgressBar) {
+            Box(
               modifier =
                 Modifier
-                  .background(
-                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                    RoundedCornerShape(8.dp),
-                  )
-                  .padding(horizontal = 8.dp, vertical = 4.dp),
-              color = MaterialTheme.colorScheme.onSurface,
-            )
+                  .align(Alignment.BottomCenter)
+                  .fillMaxWidth()
+                  .height(4.dp),
+            ) {
+              // Background (unwatched portion)
+              Box(
+                modifier =
+                  Modifier
+                    .matchParentSize()
+                    .background(Color.Black.copy(alpha = 0.6f)),
+              )
+              // Progress (watched portion)
+              Box(
+                modifier =
+                  Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(progressPercentage)
+                    .background(MaterialTheme.colorScheme.primary),
+              )
+            }
+          }
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(
+          modifier = Modifier.weight(1f),
+        ) {
+          Text(
+            video.displayName,
+            style = MaterialTheme.typography.titleSmall,
+            color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis,
+          )
+          Spacer(modifier = Modifier.height(4.dp))
+          Row {
+            if (showSizeChip && video.sizeFormatted != "0 B" && video.sizeFormatted != "--") {
+              Text(
+                video.sizeFormatted,
+                style = MaterialTheme.typography.labelSmall,
+                modifier =
+                  Modifier
+                    .background(
+                      MaterialTheme.colorScheme.surfaceContainerHigh,
+                      RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+            }
+            if (showResolutionChip && video.resolution != "--") {
+              if (showSizeChip && video.sizeFormatted != "0 B" && video.sizeFormatted != "--") {
+                Spacer(modifier = Modifier.width(4.dp))
+              }
+
+              // Extract base resolution without FPS for display
+              val displayResolution = if (showFramerateInResolution) {
+                video.resolution
+              } else {
+                // Remove @fps part if present
+                video.resolution.substringBefore("@")
+              }
+
+              Text(
+                displayResolution,
+                style = MaterialTheme.typography.labelSmall,
+                modifier =
+                  Modifier
+                    .background(
+                      MaterialTheme.colorScheme.surfaceContainerHigh,
+                      RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+            }
           }
         }
       }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/dialogs/SortDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
@@ -36,6 +37,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Slider
+import androidx.compose.material3.VerticalDivider
 
 @Composable
 fun SortDialog(
@@ -52,6 +55,9 @@ fun SortDialog(
   modifier: Modifier = Modifier,
   visibilityToggles: List<VisibilityToggle> = emptyList(),
   viewModeSelector: ViewModeSelector? = null,
+  layoutModeSelector:  ViewModeSelector? = null,
+  folderGridColumnSelector: GridColumnSelector? = null,
+  videoGridColumnSelector: GridColumnSelector? = null,
   showSortOptions: Boolean = true,
 ) {
   if (!isOpen) return
@@ -101,6 +107,18 @@ fun SortDialog(
           )
         }
 
+        if (layoutModeSelector != null) {
+          ViewModeSelectorComponent(
+            viewModeSelector = layoutModeSelector,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        GridColumnsSection(
+          folderGridColumnSelector = folderGridColumnSelector,
+          videoGridColumnSelector = videoGridColumnSelector,
+        )
+
         if (visibilityToggles.isNotEmpty()) {
           VisibilityTogglesSection(
             toggles = visibilityToggles,
@@ -131,6 +149,14 @@ data class ViewModeSelector(
   val secondOptionIcon: ImageVector,
   val isFirstOptionSelected: Boolean,
   val onViewModeChange: (Boolean) -> Unit,
+)
+
+data class GridColumnSelector(
+  val label: String,
+  val currentValue: Int,
+  val onValueChange: (Int) -> Unit,
+  val valueRange: ClosedFloatingPointRange<Float> = 1f..4f,
+  val steps: Int = 2,
 )
 
 // -----------------------------------------------------------------------------
@@ -360,6 +386,126 @@ private fun VisibilityTogglesSection(
               null
             },
         )
+      }
+    }
+  }
+}
+
+@Composable
+private fun GridColumnSelectorComponent(
+  gridColumnSelector: GridColumnSelector,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = gridColumnSelector.label,
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.Medium,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
+
+    Slider(
+      value = gridColumnSelector.currentValue.toFloat(),
+      onValueChange = { gridColumnSelector.onValueChange(it.toInt()) },
+      valueRange = gridColumnSelector.valueRange,
+      steps = gridColumnSelector.steps,
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    Text(
+      text = "${gridColumnSelector.currentValue} columns",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier = Modifier.align(Alignment.CenterHorizontally),
+    )
+  }
+}
+
+@Composable
+private fun GridColumnsSection(
+  folderGridColumnSelector: GridColumnSelector?,
+  videoGridColumnSelector: GridColumnSelector?,
+  modifier: Modifier = Modifier,
+) {
+  if (folderGridColumnSelector == null && videoGridColumnSelector == null) return
+
+  Column(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "Grid Columns",
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.Medium,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
+
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+      verticalAlignment = Alignment.Top,
+    ) {
+      if (folderGridColumnSelector != null) {
+        Column(
+          modifier = Modifier.weight(1f),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text(
+            text = "Folder Grid",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+          Slider(
+            value = folderGridColumnSelector.currentValue.toFloat(),
+            onValueChange = { folderGridColumnSelector.onValueChange(it.toInt()) },
+            valueRange = folderGridColumnSelector.valueRange,
+            steps = folderGridColumnSelector.steps,
+            modifier = Modifier.fillMaxWidth(),
+          )
+          Text(
+            text = "${folderGridColumnSelector.currentValue} columns",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+          )
+        }
+      }
+
+      if (folderGridColumnSelector != null && videoGridColumnSelector != null) {
+        VerticalDivider(
+          modifier = Modifier.padding(vertical = 8.dp),
+          thickness = 1.dp,
+          color = MaterialTheme.colorScheme.outline,
+        )
+      }
+
+      if (videoGridColumnSelector != null) {
+        Column(
+          modifier = Modifier.weight(1f),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text(
+            text = "Video Grid",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+          Slider(
+            value = videoGridColumnSelector.currentValue.toFloat(),
+            onValueChange = { videoGridColumnSelector.onValueChange(it.toInt()) },
+            valueRange = videoGridColumnSelector.valueRange,
+            steps = videoGridColumnSelector.steps,
+            modifier = Modifier.fillMaxWidth(),
+          )
+          Text(
+            text = "${videoGridColumnSelector.currentValue} columns",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+          )
+        }
       }
     }
   }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -197,7 +197,8 @@ object NetworkStreamingScreen : Screen {
                     text = "No network connections",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface, // a
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
                   )
                   Spacer(modifier = Modifier.height(8.dp))
                   Text(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -197,8 +197,7 @@ object NetworkStreamingScreen : Screen {
                     text = "No network connections",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurface, // a
                   )
                   Spacer(modifier = Modifier.height(8.dp))
                   Text(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -3,6 +3,7 @@ package app.marlboroadvance.mpvex.ui.browser.videolist
 import android.content.Intent
 import android.os.Environment
 import androidx.activity.compose.BackHandler
+import androidx. compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -11,13 +12,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.filled.Title
 import androidx.compose.material.icons.filled.VideoLibrary
+import androidx. compose.material.icons.filled.ViewList
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -46,6 +53,7 @@ import app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository
 import app.marlboroadvance.mpvex.preferences.AppearancePreferences
 import app.marlboroadvance.mpvex.preferences.BrowserPreferences
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
+import app.marlboroadvance.mpvex.preferences.MediaLayoutMode
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.SortOrder
 import app.marlboroadvance.mpvex.preferences.VideoSortType
@@ -62,6 +70,7 @@ import app.marlboroadvance.mpvex.ui.browser.dialogs.FolderPickerDialog
 import app.marlboroadvance.mpvex.ui.browser.dialogs.LoadingDialog
 import app.marlboroadvance.mpvex.ui.browser.dialogs.RenameDialog
 import app.marlboroadvance.mpvex.ui.browser.dialogs.SortDialog
+import app.marlboroadvance.mpvex.ui.browser.dialogs.ViewModeSelector
 import app.marlboroadvance.mpvex.ui.browser.dialogs.VisibilityToggle
 import app.marlboroadvance.mpvex.ui.browser.selection.SelectionManager
 import app.marlboroadvance.mpvex.ui.browser.selection.rememberSelectionManager
@@ -77,6 +86,7 @@ import kotlinx.serialization.Serializable
 import my.nanihadesuka.compose.ScrollbarSettings
 import org.koin.compose.koinInject
 import java.io.File
+import app.marlboroadvance.mpvex.ui.browser.dialogs.GridColumnSelector
 import kotlin.math.roundToInt
 
 @Serializable
@@ -400,6 +410,9 @@ private fun VideoListContent(
 ) {
   val thumbnailRepository = koinInject<ThumbnailRepository>()
   val gesturePreferences = koinInject<GesturePreferences>()
+  val browserPreferences = koinInject<BrowserPreferences>()
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val videoGridColumns by browserPreferences.videoGridColumns.collectAsState()
   val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
   val density = LocalDensity.current
   val thumbWidthDp = 128.dp
@@ -481,17 +494,22 @@ private fun VideoListContent(
         listState = listState,
         modifier = modifier.fillMaxSize(),
       ) {
-        LazyColumnScrollbar(
-          state = listState,
-          settings = ScrollbarSettings(
-            thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-            thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-          ),
-        ) {
-          LazyColumn(
-            state = listState,
+
+        val columns = when (mediaLayoutMode) {
+          MediaLayoutMode.LIST -> 1
+          MediaLayoutMode.GRID -> videoGridColumns
+        }
+
+        val gridState = rememberLazyGridState()
+
+        if (mediaLayoutMode == MediaLayoutMode.GRID) {
+          LazyVerticalGrid(
+            columns = GridCells.Fixed(columns),
+            state = gridState,
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
           ) {
             items(
               count = videosWithInfo.size,
@@ -525,7 +543,60 @@ private fun VideoListContent(
                 } else {
                   { onVideoClick(videoWithInfo.video) }
                 },
+                isGridMode = mediaLayoutMode == MediaLayoutMode.GRID,
+                gridColumns = videoGridColumns,
               )
+            }
+          }
+        } else {
+          // Original list mode code unchanged
+          LazyColumnScrollbar(
+            state = listState,
+            settings = ScrollbarSettings(
+              thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
+              thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
+            ),
+          ) {
+            LazyColumn(
+              state = listState,
+              modifier = Modifier.fillMaxSize(),
+              contentPadding = PaddingValues(8.dp),
+            ) {
+              items(
+                count = videosWithInfo.size,
+                key = { index -> videosWithInfo[index].video.id },
+              ) { index ->
+                val videoWithInfo = videosWithInfo[index]
+                val isRecentlyPlayed = recentlyPlayedFilePath?.let { videoWithInfo.video.path == it } ?: false
+
+                // Prefetch upcoming thumbnails
+                androidx.compose.runtime.LaunchedEffect(index) {
+                  if (index < videosWithInfo.size - 1) {
+                    val upcomingVideos =
+                      videosWithInfo.subList(
+                        (index + 1).coerceAtMost(videosWithInfo.size),
+                        (index + 11).coerceAtMost(videosWithInfo.size),
+                      )
+                    thumbnailRepository.prefetchThumbnails(upcomingVideos.map { it.video }, thumbWidthPx, thumbHeightPx)
+                  }
+                }
+
+                VideoCard(
+                  video = videoWithInfo.video,
+                  progressPercentage = videoWithInfo.progressPercentage,
+                  isRecentlyPlayed = isRecentlyPlayed,
+                  isSelected = selectionManager.isSelected(videoWithInfo.video),
+                  isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
+                  onClick = { onVideoClick(videoWithInfo.video) },
+                  onLongClick = { onVideoLongClick(videoWithInfo.video) },
+                  onThumbClick = if (tapThumbnailToSelect) {
+                    { onVideoLongClick(videoWithInfo.video) }
+                  } else {
+                    { onVideoClick(videoWithInfo.video) }
+                  },
+                  isGridMode = false,
+                )
+              }
             }
           }
         }
@@ -544,12 +615,33 @@ private fun VideoSortDialog(
   onSortOrderChange: (SortOrder) -> Unit,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
+  val videoGridColumns by browserPreferences.videoGridColumns.collectAsState()
+  val folderGridColumns by browserPreferences.folderGridColumns.collectAsState()
   val appearancePreferences = koinInject<AppearancePreferences>()
   val showSizeChip by browserPreferences.showSizeChip.collectAsState()
   val showResolutionChip by browserPreferences.showResolutionChip.collectAsState()
   val showFramerateInResolution by browserPreferences.showFramerateInResolution.collectAsState()
   val showProgressBar by browserPreferences.showProgressBar.collectAsState()
   val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+
+  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+    GridColumnSelector(
+      label = "Folder Grid Columns",
+      currentValue = folderGridColumns,
+      onValueChange = { browserPreferences.folderGridColumns.set(it) },
+      valueRange = 3f..4f,
+      steps = 0,
+    )
+  } else null
+
+  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+    GridColumnSelector(
+      label = "Grid Columns",
+      currentValue = videoGridColumns,
+      onValueChange = { browserPreferences.videoGridColumns.set(it) },
+    )
+  } else null
 
   SortDialog(
     isOpen = isOpen,
@@ -586,6 +678,19 @@ private fun VideoSortDialog(
         else -> Pair("Asc", "Desc")
       }
     },
+    viewModeSelector = ViewModeSelector(
+      label = "Layout",
+      firstOptionLabel = "List",
+      secondOptionLabel = "Grid",
+      firstOptionIcon = Icons.Filled.ViewList,
+      secondOptionIcon = Icons. Filled.GridView,
+      isFirstOptionSelected = mediaLayoutMode == MediaLayoutMode.LIST,
+      onViewModeChange = { isFirstOption ->
+        browserPreferences.mediaLayoutMode.set(
+          if (isFirstOption) MediaLayoutMode.LIST else MediaLayoutMode.GRID
+        )
+      },
+    ),
     visibilityToggles =
       listOf(
         VisibilityToggle(
@@ -614,5 +719,7 @@ private fun VideoSortDialog(
           onCheckedChange = { browserPreferences.showProgressBar.set(it) },
         ),
       ),
+    folderGridColumnSelector = folderGridColumnSelector,
+    videoGridColumnSelector = videoGridColumnSelector,
   )
 }


### PR DESCRIPTION
- Added grid mode with slider control for browser layout
- Folder grid supports 3 and 4 column layouts
- Video grid supports 1 to 4 column layouts
- Display file size and resolution below title in 1-column video layout

<img width="1080" height="2424" alt="Screenshot_20251227-220500" src="https://github.com/user-attachments/assets/558ec51d-ad8b-436b-b9d9-372a79978609" />
<img width="1080" height="2424" alt="four-col-layout" src="https://github.com/user-attachments/assets/88376600-fba1-4b48-b3b1-f7739997b32f" />
<img width="1080" height="2424" alt="one-col-layout" src="https://github.com/user-attachments/assets/ad6447f0-f455-4fba-8bfb-94ddf7cae387" />
<img width="1080" height="2424" alt="three-col-layout" src="https://github.com/user-attachments/assets/2106bb33-2bb0-435e-801b-04e9c19f16ed" />
<img width="1080" height="2424" alt="two-col-layout" src="https://github.com/user-attachments/assets/a0cfb24f-10d9-47fa-b041-48f98515838c" />
