### PR TITLE
Add C plugin support (selection + binary copy)

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/AdvancedPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/AdvancedPreferences.kt
@@ -18,4 +18,6 @@ class AdvancedPreferences(
 
   val enableLuaScripts = preferenceStore.getBoolean("enable_lua_scripts", false)
   val selectedLuaScripts = preferenceStore.getStringSet("selected_lua_scripts", emptySet())
+  val enableCPlugins = preferenceStore.getBoolean("enable_c_plugins", false)
+  val selectedCPlugins = preferenceStore.getStringSet("selected_c_plugins", emptySet())
 }


### PR DESCRIPTION
- Add preferences/UI to enable and select .so C plugins alongside Lua scripts
- Copy selected scripts/plugins as binary streams into mpv scripts dir before init
- Keep existing Lua script flow intact while extending script management