### PR TITLE
feat: added new seek sens adjuster

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -18,6 +18,7 @@ class PlayerPreferences(
   val showDoubleTapOvals = preferenceStore.getBoolean("show_double_tap_ovals", true)
   val showSeekTimeWhileSeeking = preferenceStore.getBoolean("show_seek_time_while_seeking", true)
   val usePreciseSeeking = preferenceStore.getBoolean("use_precise_seeking", false)
+  val seekSensitivity = preferenceStore.getFloat("seek_sensitivity", 0.15f)
 
   val brightnessGesture = preferenceStore.getBoolean("gestures_brightness", true)
   val volumeGesture = preferenceStore.getBoolean("volume_brightness", true)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
@@ -95,6 +95,7 @@ fun GestureHandler(
   val swapVolumeAndBrightness by playerPreferences.swapVolumeAndBrightness.collectAsState()
   val seekGesture by playerPreferences.horizontalSeekGesture.collectAsState()
   val showSeekbarWhenSeeking by playerPreferences.showSeekBarWhenSeeking.collectAsState()
+  val seekSensitivity by playerPreferences.seekSensitivity.collectAsState()
   val pinchToZoomGesture by playerPreferences.pinchToZoomGesture.collectAsState()
   var isLongPressing by remember { mutableStateOf(false) }
   var isDynamicSpeedControlActive by remember { mutableStateOf(false) }
@@ -410,7 +411,7 @@ fun GestureHandler(
                           startingPosition,
                           startingX,
                           currentPosition.x,
-                          0.15f,
+                          seekSensitivity,
                         ).let {
                           viewModel.gestureSeekAmount.update { _ ->
                             Pair(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
@@ -281,7 +281,7 @@ fun GestureHandler(
           var lastMPVVolumeValue = currentMPVVolume ?: 100
           var lastBrightnessValue = currentBrightness
           val brightnessGestureSens = 0.001f
-          val volumeGestureSens = 0.03f
+          val volumeGestureSens = 0.1f
           val mpvVolumeGestureSens = 0.02f
           val isIncreasingVolumeBoost: (Float) -> Boolean = {
             volumeBoostingCap > 0 && currentVolume == viewModel.maxVolume &&

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -188,6 +188,24 @@ object PlayerPreferencesScreen : Screen {
                 onValueChange = preferences.usePreciseSeeking::set,
                 title = { Text(stringResource(R.string.pref_player_use_precise_seeking)) },
               )
+
+              PreferenceDivider()
+
+              val seekSensitivity by preferences.seekSensitivity.collectAsState()
+              SliderPreference(
+                value = seekSensitivity,
+                onValueChange = { preferences.seekSensitivity.set(it.toFixed(2)) },
+                title = { Text(stringResource(R.string.pref_player_seek_sensitivity)) },
+                valueRange = 0.01f..0.3f,
+                summary = {
+                  Text(
+                    "%.2f".format(seekSensitivity),
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+                onSliderValueChange = { preferences.seekSensitivity.set(it.toFixed(2)) },
+                sliderValue = seekSensitivity,
+              )
             }
           }
           // Gestures Section

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <!-- Media Info Activity -->
 
     <string name="pref_player_use_precise_seeking">Use precise seeking</string>
+    <string name="pref_player_seek_sensitivity">Seek sensitivity</string>
 
     <!-- Folders Preferences -->
     <string name="pref_folders_title">Folders</string>


### PR DESCRIPTION
I found that the default seeking sensitivity was too high for my use case, so I added a setting that allows users to adjust the seek sensitivity directly. I believe this feature would be useful for others as well, which is why I’m submitting this pull request.

![Screenshot_2026-01-02-19-09-09-098_app marlboroadvance mpvex debug](https://github.com/user-attachments/assets/589d9c63-ed53-4374-b50d-79989f8c04b4)
