### PR TITLE
fix: gesture reliability, stuck UI, and network subtitles

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
@@ -325,9 +325,10 @@ fun GestureHandler(
                       viewModel.handleCenterDoubleTap()
                     }
                   }
-                } else if (tapCount == 0 || timeSinceLastTap >= doubleTapTimeout) {
-                  // Single tap or timed out - start new tap sequence
+                } else if (tapCount == 0 || timeSinceLastTap >= doubleTapTimeout || lastTapRegion != region) {
+                  // Single tap, timed out, or region switch - start new tap sequence
                   tapCount = 1
+                  isDoubleTapSeeking = false
                   lastTapTime = downTime
                   lastTapPosition = downPosition
                   lastTapRegion = region
@@ -344,7 +345,7 @@ fun GestureHandler(
         }
       }
       .pointerInput(areControlsLocked, multipleSpeedGesture, seekGesture, brightnessGesture, volumeGesture) {
-        if ((!seekGesture && !brightnessGesture && !volumeGesture) || areControlsLocked) return@pointerInput
+        if ((!seekGesture && !brightnessGesture && !volumeGesture && multipleSpeedGesture <= 0f) || areControlsLocked) return@pointerInput
 
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false)

--- a/app/src/main/java/app/marlboroadvance/mpvex/utils/media/SubtitleOps.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/utils/media/SubtitleOps.kt
@@ -115,7 +115,7 @@ object SubtitleOps : KoinComponent {
       val subtitles = files.filter { file ->
         !file.isDirectory &&
           isSubtitleFile(file.name) &&
-          file.name.substringBeforeLast('.').equals(baseName, ignoreCase = true)
+          file.name.substringBeforeLast('.').startsWith(baseName, ignoreCase = true)
       }
 
       if (subtitles.isEmpty()) {


### PR DESCRIPTION
- Fix 'hold for speed' gesture being disabled when volume/brightness gestures are off #389 
- Fix unreliable double-tap seeking by handling direction switching immediately
  Fix player UI getting stuck by strictly resetting seek state on new taps #388
- network subtitle loading to support (need to be tested thoroughly) #385  