### PR TITLE
feat: enhance player controls and add autoplay next video

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -55,6 +55,7 @@ class PlayerPreferences(
   val includeSubtitlesInSnapshot = preferenceStore.getBoolean("include_subtitles_in_snapshot", false)
 
   val playlistMode = preferenceStore.getBoolean("playlist_mode", true)
+  val autoplayNextVideo = preferenceStore.getBoolean("autoplay_next_video", true)
 
   val useWavySeekbar = preferenceStore.getBoolean("use_wavy_seekbar", true)
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/presentation/components/OutlinedNumericChooser.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/presentation/components/OutlinedNumericChooser.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.RemoveCircle
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -34,8 +34,8 @@ fun OutlinedNumericChooser(
   min: Int = 0,
   suffix: (@Composable () -> Unit)? = null,
   label: (@Composable () -> Unit)? = null,
-  decreaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.RemoveCircle,
-  increaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.AddCircle,
+  decreaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.Remove,
+  increaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.Add,
   valueFormatter: ((Int) -> String)? = null,
 ) {
   assert(max > min) { "min can't be larger than max ($min > $max)" }
@@ -82,7 +82,7 @@ fun OutlinedNumericChooser(
       onClick = { onChange(value + step) },
       modifier = Modifier.size(48.dp)
     ) {
-      Icon(Icons.Filled.AddCircle, null)
+      Icon(increaseIcon, null)
     }
   }
 }
@@ -97,8 +97,8 @@ fun OutlinedNumericChooser(
   min: Float = 0f,
   suffix: (@Composable () -> Unit)? = null,
   label: (@Composable () -> Unit)? = null,
-  decreaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.RemoveCircle,
-  increaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.AddCircle,
+  decreaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.Remove,
+  increaseIcon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Filled.Add,
   valueFormatter: ((Float) -> String)? = null,
 ) {
   assert(max > min) { "min can't be larger than max ($min > $max)" }
@@ -147,7 +147,7 @@ fun OutlinedNumericChooser(
       onClick = { onChange(value + step) },
       modifier = Modifier.size(48.dp)
     ) {
-      Icon(Icons.Filled.AddCircle, null)
+      Icon(increaseIcon, null)
     }
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/presentation/components/RepeatingIconButton.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/presentation/components/RepeatingIconButton.kt
@@ -2,7 +2,7 @@ package app.marlboroadvance.mpvex.presentation.components
 
 import android.view.MotionEvent
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,22 +22,22 @@ fun RepeatingIconButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-  maxDelayMillis: Long = 500,
-  minDelayMillis: Long = 50,
-  delayDecayFactor: Float = .15f,
+  maxDelayMillis: Long = 300,
+  minDelayMillis: Long = 20,
+  delayDecayFactor: Float = .25f,
   content: @Composable () -> Unit,
 ) {
   val currentClickListener by rememberUpdatedState(onClick)
   var pressed by remember { mutableStateOf(false) }
 
-  IconButton(
+  FilledTonalIconButton(
     modifier =
       modifier.pointerInteropFilter {
         pressed =
           when (it.action) {
-            MotionEvent.ACTION_DOWN -> true
-
-            else -> false
+            MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> true
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> false
+            else -> pressed
           }
 
         true

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -1449,7 +1449,10 @@ class PlayerActivity :
           playlistIndex < playlist.size - 1
         }
 
-        if (hasNextItem) {
+        // Check if autoplay next video is enabled
+        val autoplayEnabled = playerPreferences.autoplayNextVideo.get()
+
+        if (hasNextItem && autoplayEnabled) {
           // Play next item in playlist
           playNext()
         } else if (viewModel.shouldRepeatPlaylist()) {
@@ -1466,9 +1469,10 @@ class PlayerActivity :
             loadPlaylistItem(0)
           }
         } else if (playerPreferences.closeAfterReachingEndOfVideo.get()) {
-          // No repeat, end of playlist: close if setting is enabled
+          // No autoplay or no next item, end of playlist: close if setting is enabled
           finishAndRemoveTask()
         }
+        // If autoplay is off and closeAfterReachingEndOfVideo is off, just stay on current video
       } else {
         // Single video playback (no playlist)
         if (playerPreferences.closeAfterReachingEndOfVideo.get()) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/PlaybackSpeedSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/PlaybackSpeedSheet.kt
@@ -60,6 +60,7 @@ import `is`.xyz.mpv.MPVLib
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
 import org.koin.compose.koinInject
+import app.marlboroadvance.mpvex.presentation.components.RepeatingIconButton
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
@@ -144,7 +145,7 @@ fun PlaybackSpeedSheet(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
       ) {
-         FilledTonalIconButton(
+         RepeatingIconButton(
            onClick = { onSpeedChange((speed - 0.05f).coerceAtLeast(0.05f)) },
            modifier = Modifier.size(40.dp)
         ) {
@@ -162,7 +163,7 @@ fun PlaybackSpeedSheet(
             modifier = Modifier.weight(1f)
           )
           
-        FilledTonalIconButton(
+        RepeatingIconButton(
            onClick = { onSpeedChange((speed + 0.05f).coerceAtMost(10f)) },
            modifier = Modifier.size(40.dp)
         ) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -113,15 +113,33 @@ object PlayerPreferencesScreen : Screen {
               
               PreferenceDivider()
               
+              val autoplayNextVideo by preferences.autoplayNextVideo.collectAsState()
+              SwitchPreference(
+                value = autoplayNextVideo,
+                onValueChange = preferences.autoplayNextVideo::set,
+                title = { Text(text = "Autoplay next video") },
+                summary = {
+                  Text(
+                    text = if (autoplayNextVideo)
+                      "Automatically play next video when current ends"
+                    else
+                      "Stay on current video when it ends",
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+              )
+              
+              PreferenceDivider()
+              
               val playlistMode by preferences.playlistMode.collectAsState()
               SwitchPreference(
                 value = playlistMode,
                 onValueChange = preferences.playlistMode::set,
-                title = { Text(text = "Autoplay") },
+                title = { Text(text = "Enable next/previous navigation") },
                 summary = {
                   Text(
                     text = if (playlistMode)
-                      "Automatically enable next/previous navigation for all videos in folder"
+                      "Show next/previous buttons for all videos in folder"
                     else
                       "Play videos individually (select multiple for playlist)",
                     color = MaterialTheme.colorScheme.outline,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SearchablePreference.kt
@@ -162,7 +162,14 @@ object SearchablePreferences {
             add(SearchablePreference(
                 titleRes = R.string.pref_autoplay_title,
                 summaryRes = R.string.pref_autoplay_summary,
-                keywords = listOf("autoplay", "playlist", "next", "previous", "folder"),
+                keywords = listOf("autoplay", "playlist", "next", "previous", "folder", "navigation"),
+                category = "Player",
+                screen = PlayerPreferencesScreen,
+            ))
+            add(SearchablePreference(
+                titleRes = R.string.pref_autoplay_next_video_title,
+                summaryRes = R.string.pref_autoplay_next_video_summary,
+                keywords = listOf("autoplay", "next", "video", "auto", "advance", "continuous"),
                 category = "Player",
                 screen = PlayerPreferencesScreen,
             ))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,8 +74,10 @@
     <string name="settings_search_title">Search</string>
 
     <!-- Player Preferences Hardcoded -->
-    <string name="pref_autoplay_title">Autoplay</string>
-    <string name="pref_autoplay_summary">Automatically enable next/previous navigation for all videos in folder</string>
+    <string name="pref_autoplay_title">Enable next/previous navigation</string>
+    <string name="pref_autoplay_summary">Show next/previous buttons for all videos in folder</string>
+    <string name="pref_autoplay_next_video_title">Autoplay next video</string>
+    <string name="pref_autoplay_next_video_summary">Automatically play next video when current ends</string>
     <string name="pref_auto_pip_title">Auto Picture-in-Picture</string>
     <string name="pref_auto_pip_summary">Automatically enter PIP mode when pressing home or back</string>
     <string name="pref_dynamic_speed_overlay_title">Dynamic Speed Overlay</string>


### PR DESCRIPTION
- Update +/- buttons with filled tonal background and simple icons

- Improve RepeatingIconButton with faster repeat and proper touch handling

- Add 'Autoplay next video' preference for auto-advancing to next video #400 

- Rename 'Autoplay' to 'Enable next/previous navigation' for clarity

- Apply RepeatingIconButton to PlaybackSpeedSheet for consistent UX