### PR TITLE
Floating nav

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/AppearancePreferences.kt
@@ -30,6 +30,7 @@ class AppearancePreferences(
   val unplayedOldVideoDays = preferenceStore.getInt("unplayed_old_video_days", 7)
   val showNetworkThumbnails = preferenceStore.getBoolean("show_network_thumbnails", false)
   val seekbarStyle = preferenceStore.getEnum("seekbar_style", SeekbarStyle.Wavy)
+  val useFloatingNavigation = preferenceStore.getBoolean("use_floating_navigation", true)
 
   val topLeftControls =
     preferenceStore.getString(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/MainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.scaleIn
@@ -25,7 +24,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.ProvideTextStyle
@@ -62,8 +60,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -319,11 +315,12 @@ object MainScreen : Screen {
             enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
             exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
           ) {
-            if (useFloatingNavigation) {
-              // Floating Navigation Bar - styled like Pixel Player
               // Get system navigation bar inset for proper spacing
               val systemNavBarInset = WindowInsets.navigationBars
                 .asPaddingValues().calculateBottomPadding()
+
+              if (useFloatingNavigation) {
+                // Floating Navigation Bar - styled like Pixel Player
               
               Box(
                 modifier = Modifier
@@ -376,27 +373,48 @@ object MainScreen : Screen {
                 }
               }
             } else {
-              // Standard Navigation Bar
-              NavigationBar(
+              androidx.compose.material3.Surface(
                 modifier = Modifier.fillMaxWidth(),
+                color = androidx.compose.material3.NavigationBarDefaults.containerColor,
+                tonalElevation = androidx.compose.material3.NavigationBarDefaults.Elevation
               ) {
-                items.forEachIndexed { index, item ->
-                  val isSelected = selectedTab == index
-                  val selectedIcon = selectedIcons[index]
-                  val unselectedIcon = unselectedIcons[index]
-                  
-                  NavigationBarItem(
-                    selected = isSelected,
-                    onClick = { selectedTab = index },
-                    icon = {
-                      Icon(
-                        imageVector = if (isSelected) selectedIcon else unselectedIcon,
-                        contentDescription = item
+                Column {
+                  Row(
+                    modifier = Modifier
+                      .fillMaxWidth()
+                      .height(80.dp) // Standard height
+                      .padding(horizontal = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceAround,
+                    verticalAlignment = Alignment.CenterVertically
+                  ) {
+                    items.forEachIndexed { index, item ->
+                      val isSelected = selectedTab == index
+                      val selectedIcon = selectedIcons[index]
+                      val unselectedIcon = unselectedIcons[index]
+                      
+                      CustomNavigationBarItem(
+                        selected = isSelected,
+                        onClick = { selectedTab = index },
+                        icon = {
+                          Icon(
+                            imageVector = unselectedIcon,
+                            contentDescription = item
+                          )
+                        },
+                        selectedIcon = {
+                          Icon(
+                            imageVector = selectedIcon,
+                            contentDescription = item
+                          )
+                        },
+                        label = { Text(item) },
+                        contentDescription = item,
+                        alwaysShowLabel = true
                       )
-                    },
-                    label = { Text(item) },
-                    alwaysShowLabel = true
-                  )
+                    }
+                  }
+                  // Spacer for system navigation bar inset
+                  Spacer(modifier = Modifier.height(systemNavBarInset))
                 }
               }
             }
@@ -405,8 +423,7 @@ object MainScreen : Screen {
       floatingActionButton = {
         // Only show FAB when not in selection mode, not on Network tab (index 3), and permission is granted
         // For Folders tab (0), also check storage permission directly
-        val shouldShowFab = !isInSelectionMode.value && selectedTab != 3 && 
-                           (selectedTab != 0 || currentHasPermission)
+        val shouldShowFab = !isInSelectionMode.value && selectedTab != 3 && (selectedTab != 0 || currentHasPermission)
         if (shouldShowFab) {
           AnimatedVisibility(
             visible = true,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/MainScreen.kt
@@ -9,32 +9,13 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.ProvideTextStyle
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -309,115 +290,56 @@ object MainScreen : Screen {
     Scaffold(
       modifier = Modifier.fillMaxSize(),
       bottomBar = {
-          // Navigation Bar Logic
           AnimatedVisibility(
             visible = !hideNavigationBar.value,
             enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
             exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
           ) {
-              // Get system navigation bar inset for proper spacing
-              val systemNavBarInset = WindowInsets.navigationBars
-                .asPaddingValues().calculateBottomPadding()
-
-              if (useFloatingNavigation) {
-                // Floating Navigation Bar - styled like Pixel Player
+              val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
               
-              Box(
-                modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(bottom = systemNavBarInset) // Space above system nav bar
-              ) {
-                // Floating Surface with rounded corners and shadow
-                androidx.compose.material3.Surface(
-                  modifier = Modifier
-                    .fillMaxWidth()
-                    .height(90.dp)
-                    .padding(horizontal = 14.dp), // Horizontal padding for floating effect
-                  color = androidx.compose.material3.NavigationBarDefaults.containerColor,
-                  shape = RoundedCornerShape(26.dp), // Rounded corners for pill shape
-                  shadowElevation = 3.dp, // Shadow for floating effect
-                  tonalElevation = 2.dp
-                ) {
-                  Row(
-                    modifier = Modifier
-                      .fillMaxSize()
-                      .padding(horizontal = 10.dp),
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically
+              if (useFloatingNavigation) {
+                  androidx.compose.material3.Surface(
+                      modifier = Modifier
+                          .fillMaxWidth()
+                          .padding(start = 14.dp, end = 14.dp, bottom = systemNavBarInset + 8.dp),
+                      color = androidx.compose.material3.NavigationBarDefaults.containerColor,
+                      shape = RoundedCornerShape(26.dp),
+                      shadowElevation = 3.dp,
+                      tonalElevation = 2.dp
                   ) {
-                    items.forEachIndexed { index, item ->
-                      val isSelected = selectedTab == index
-                      val selectedIcon = selectedIcons[index]
-                      val unselectedIcon = unselectedIcons[index]
-                      
-                      CustomNavigationBarItem(
-                        selected = isSelected,
-                        onClick = { selectedTab = index },
-                        icon = {
-                          Icon(
-                            imageVector = unselectedIcon,
-                            contentDescription = item
-                          )
-                        },
-                        selectedIcon = {
-                          Icon(
-                            imageVector = selectedIcon,
-                            contentDescription = item
-                          )
-                        },
-                        label = { Text(item) },
-                        contentDescription = item
-                      )
-                    }
+                      NavigationBar(
+                          containerColor = androidx.compose.ui.graphics.Color.Transparent,
+                          tonalElevation = 0.dp,
+                          windowInsets = WindowInsets(0.dp)
+                      ) {
+                          items.forEachIndexed { index, item ->
+                              NavigationBarItem(
+                                  selected = selectedTab == index,
+                                  onClick = { selectedTab = index },
+                                  icon = { Icon(unselectedIcons[index], contentDescription = item) },
+                                  label = { Text(item) },
+                                  alwaysShowLabel = true
+                              )
+                          }
+                      }
                   }
-                }
-              }
-            } else {
-              androidx.compose.material3.Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = androidx.compose.material3.NavigationBarDefaults.containerColor,
-                tonalElevation = androidx.compose.material3.NavigationBarDefaults.Elevation
-              ) {
-                Column {
-                  Row(
-                    modifier = Modifier
-                      .fillMaxWidth()
-                      .height(80.dp) // Standard height
-                      .padding(horizontal = 8.dp),
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically
+              } else {
+                  NavigationBar(
+                      containerColor = androidx.compose.material3.NavigationBarDefaults.containerColor,
+                      tonalElevation = androidx.compose.material3.NavigationBarDefaults.Elevation,
+                      windowInsets = WindowInsets.navigationBars
                   ) {
-                    items.forEachIndexed { index, item ->
-                      val isSelected = selectedTab == index
-                      val selectedIcon = selectedIcons[index]
-                      val unselectedIcon = unselectedIcons[index]
-                      
-                      CustomNavigationBarItem(
-                        selected = isSelected,
-                        onClick = { selectedTab = index },
-                        icon = {
-                          Icon(
-                            imageVector = unselectedIcon,
-                            contentDescription = item
+                      items.forEachIndexed { index, item ->
+                          NavigationBarItem(
+                              selected = selectedTab == index,
+                              onClick = { selectedTab = index },
+                              icon = { Icon(unselectedIcons[index], contentDescription = item) },
+                              label = { Text(item) },
+                              alwaysShowLabel = true
                           )
-                        },
-                        selectedIcon = {
-                          Icon(
-                            imageVector = selectedIcon,
-                            contentDescription = item
-                          )
-                        },
-                        label = { Text(item) },
-                        contentDescription = item,
-                        alwaysShowLabel = true
-                      )
-                    }
+                      }
                   }
-                  // Spacer for system navigation bar inset
-                  Spacer(modifier = Modifier.height(systemNavBarInset))
-                }
               }
-            }
           }
       },
       floatingActionButton = {
@@ -788,126 +710,3 @@ object MainScreen : Screen {
     )
   }
 }
-
-// Custom Navigation Bar Item from PixelPlayer
-@Composable
-private fun RowScope.CustomNavigationBarItem(
-    selected: Boolean,
-    onClick: () -> Unit,
-    icon: @Composable () -> Unit,
-    selectedIcon: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    label: @Composable (() -> Unit)? = null,
-    contentDescription: String? = null,
-    alwaysShowLabel: Boolean = true,
-    selectedIconColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
-    unselectedIconColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
-    selectedTextColor: Color = MaterialTheme.colorScheme.onSurface,
-    unselectedTextColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
-    indicatorColor: Color = MaterialTheme.colorScheme.secondaryContainer,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
-) {
-    // Animated colors
-    val iconColor by animateColorAsState(
-        targetValue = if (selected) selectedIconColor else unselectedIconColor,
-        animationSpec = tween(durationMillis = 150),
-        label = "iconColor"
-    )
-
-    val textColor by animateColorAsState(
-        targetValue = if (selected) selectedTextColor else unselectedTextColor,
-        animationSpec = tween(durationMillis = 150),
-        label = "textColor"
-    )
-
-    val showLabel = label != null && (alwaysShowLabel || selected)
-
-    Column(
-        modifier = modifier
-            .weight(1f)
-            .fillMaxHeight()
-            .clickable(
-                onClick = { if (!selected) onClick() else null },
-                enabled = enabled,
-                role = Role.Tab,
-                interactionSource = interactionSource,
-                indication = null
-            )
-            .semantics {
-                 if (contentDescription != null) {
-                     this.contentDescription = contentDescription
-                 }
-            },
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier.size(64.dp, 32.dp)
-        ) {
-            androidx.compose.animation.AnimatedVisibility(
-                visible = selected,
-                enter = fadeIn(animationSpec = tween(100)) + 
-                        scaleIn(
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioMediumBouncy,
-                                stiffness = Spring.StiffnessLow
-                            )
-                        ),
-                exit = fadeOut(animationSpec = tween(100)) +
-                        scaleOut(animationSpec = tween(100, easing = EaseInQuart))
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 4.dp)
-                        .background(
-                            color = indicatorColor,
-                            shape = RoundedCornerShape(16.dp)
-                        )
-                )
-            }
-
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(48.dp, 24.dp)
-                    .clip(RoundedCornerShape(12.dp))
-            ) {
-                CompositionLocalProvider(LocalContentColor provides iconColor) {
-                    Box(
-                        modifier = Modifier.clearAndSetSemantics {
-                            if (showLabel) {
-                                // Semantics handled at top level
-                            }
-                        }
-                    ) {
-                        if (selected) selectedIcon() else icon()
-                    }
-                }
-            }
-        }
-
-        androidx.compose.animation.AnimatedVisibility(
-            visible = showLabel,
-            enter = fadeIn(animationSpec = tween(200, delayMillis = 50)),
-            exit = fadeOut(animationSpec = tween(100))
-        ) {
-            Spacer(modifier = Modifier.height(4.dp))
-            Box(modifier = Modifier.padding(top = 4.dp)) {
-                ProvideTextStyle(
-                    value = MaterialTheme.typography.labelMedium.copy(
-                        color = textColor,
-                        fontSize = 13.sp,
-                        fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal
-                    )
-                ) {
-                    label?.invoke()
-                }
-            }
-        }
-    }
-}
-
-private val EaseInQuart = CubicBezierEasing(0.5f, 0f, 0.75f, 0f)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/BrowserBottomBar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/BrowserBottomBar.kt
@@ -7,14 +7,11 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DriveFileMove
@@ -22,13 +19,10 @@ import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DriveFileRenameOutline
-import androidx.compose.material.icons.filled.PlaylistAdd
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -55,7 +49,7 @@ fun BrowserBottomBar(
 ) {
   val appearancePreferences = koinInject<AppearancePreferences>()
   val useFloatingNavigation by appearancePreferences.useFloatingNavigation.collectAsState()
-
+  val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
   AnimatedVisibility(
     visible = isSelectionMode,
@@ -63,41 +57,27 @@ fun BrowserBottomBar(
     exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
   ) {
     if (useFloatingNavigation) {
-      // Floating Style
-        val systemNavBarInset = WindowInsets.navigationBars
-            .asPaddingValues().calculateBottomPadding()
-
-        Box(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(bottom = systemNavBarInset) // Space above system nav bar
+      androidx.compose.material3.Surface(
+        modifier = modifier
+          .fillMaxWidth()
+          .padding(start = 14.dp, end = 14.dp, bottom = systemNavBarInset + 8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(26.dp),
+        shadowElevation = 3.dp,
+        tonalElevation = 2.dp
+      ) {
+        Row(
+          modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+          horizontalArrangement = Arrangement.SpaceEvenly,
+          verticalAlignment = Alignment.CenterVertically,
         ) {
-            Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(90.dp)
-                    .padding(horizontal = 14.dp),
-                color = MaterialTheme.colorScheme.surfaceContainer,
-                shape = RoundedCornerShape(26.dp),
-                shadowElevation = 3.dp,
-                tonalElevation = 2.dp
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 10.dp),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    BrowserBottomBarContent(
-                        onCopyClick, onMoveClick, onRenameClick, onDeleteClick, onAddToPlaylistClick,
-                        showCopy, showMove, showRename, showDelete, showAddToPlaylist
-                    )
-                }
-            }
+          BrowserBottomBarContent(
+            onCopyClick, onMoveClick, onRenameClick, onDeleteClick, onAddToPlaylistClick,
+            showCopy, showMove, showRename, showDelete, showAddToPlaylist
+          )
         }
+      }
     } else {
-      // Standard Style
       BottomAppBar(
         modifier = modifier,
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -108,10 +88,10 @@ fun BrowserBottomBar(
           horizontalArrangement = Arrangement.SpaceEvenly,
           verticalAlignment = Alignment.CenterVertically,
         ) {
-            BrowserBottomBarContent(
-                onCopyClick, onMoveClick, onRenameClick, onDeleteClick, onAddToPlaylistClick,
-                showCopy, showMove, showRename, showDelete, showAddToPlaylist
-            )
+          BrowserBottomBarContent(
+            onCopyClick, onMoveClick, onRenameClick, onDeleteClick, onAddToPlaylistClick,
+            showCopy, showMove, showRename, showDelete, showAddToPlaylist
+          )
         }
       }
     }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/BrowserBottomBar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/BrowserBottomBar.kt
@@ -1,11 +1,21 @@
 package app.marlboroadvance.mpvex.ui.browser.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DriveFileMove
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
@@ -17,10 +27,16 @@ import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.marlboroadvance.mpvex.preferences.AppearancePreferences
+import app.marlboroadvance.mpvex.preferences.preference.collectAsState
+import org.koin.compose.koinInject
 
 @Composable
 fun BrowserBottomBar(
@@ -37,21 +53,84 @@ fun BrowserBottomBar(
   showDelete: Boolean = true,
   showAddToPlaylist: Boolean = true,
 ) {
+  val appearancePreferences = koinInject<AppearancePreferences>()
+  val useFloatingNavigation by appearancePreferences.useFloatingNavigation.collectAsState()
+
+
   AnimatedVisibility(
     visible = isSelectionMode,
-    enter = slideInVertically(initialOffsetY = { it }),
-    exit = slideOutVertically(targetOffsetY = { it }),
+    enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+    exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
   ) {
-    BottomAppBar(
-      modifier = modifier,
-      containerColor = MaterialTheme.colorScheme.surfaceContainer,
-      tonalElevation = 3.dp,
-    ) {
-      Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-        verticalAlignment = Alignment.CenterVertically,
+    if (useFloatingNavigation) {
+      // Floating Style
+        val systemNavBarInset = WindowInsets.navigationBars
+            .asPaddingValues().calculateBottomPadding()
+
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(bottom = systemNavBarInset) // Space above system nav bar
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(90.dp)
+                    .padding(horizontal = 14.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                shape = RoundedCornerShape(26.dp),
+                shadowElevation = 3.dp,
+                tonalElevation = 2.dp
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    BrowserBottomBarContent(
+                        onCopyClick, onMoveClick, onRenameClick, onDeleteClick, onAddToPlaylistClick,
+                        showCopy, showMove, showRename, showDelete, showAddToPlaylist
+                    )
+                }
+            }
+        }
+    } else {
+      // Standard Style
+      BottomAppBar(
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 3.dp,
       ) {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceEvenly,
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BrowserBottomBarContent(
+                onCopyClick, onMoveClick, onRenameClick, onDeleteClick, onAddToPlaylistClick,
+                showCopy, showMove, showRename, showDelete, showAddToPlaylist
+            )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BrowserBottomBarContent(
+    onCopyClick: () -> Unit,
+    onMoveClick: () -> Unit,
+    onRenameClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onAddToPlaylistClick: () -> Unit,
+    showCopy: Boolean,
+    showMove: Boolean,
+    showRename: Boolean,
+    showDelete: Boolean,
+    showAddToPlaylist: Boolean
+) {
         if (showCopy) {
           IconButton(onClick = onCopyClick) {
             Icon(
@@ -104,7 +183,4 @@ fun BrowserBottomBar(
             )
           }
         }
-      }
-    }
-  }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/dialogs/FilePickerDialog.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/dialogs/FilePickerDialog.kt
@@ -1,0 +1,384 @@
+package app.marlboroadvance.mpvex.ui.browser.dialogs
+
+import android.content.Context
+import android.os.Environment
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.DriveFolderUpload
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.SdCard
+import androidx.compose.material.icons.filled.Usb
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import app.marlboroadvance.mpvex.utils.storage.StorageScanUtils
+import java.io.File
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun FilePickerDialog(
+  modifier: Modifier = Modifier,
+  isOpen: Boolean,
+  currentPath: String = Environment.getExternalStorageDirectory().absolutePath,
+  onDismiss: () -> Unit,
+  onFileSelected: (String) -> Unit,
+  onSystemPickerRequest: () -> Unit,
+  allowedExtensions: List<String> = listOf(
+    // Common & modern
+    "srt", "vtt", "ass", "ssa",
+
+    // DVD / Blu-ray
+    "sub", "idx", "sup",
+
+    // Streaming / XML / Professional
+    "xml", "ttml", "dfxp", "itt", "ebu", "imsc", "usf",
+
+    // Online platforms
+    "sbv", "srv1", "srv2", "srv3", "json",
+
+    // Legacy & niche
+    "sami", "smi", "mpl", "pjs", "stl", "rt", "psb", "cap",
+
+    // Broadcast captions
+    "scc", "vttx",
+
+    // Karaoke / lyrics
+    "lrc", "krc",
+
+    // Fallback / raw text
+    "txt"
+  )
+
+) {
+  if (!isOpen) return
+
+  val context = LocalContext.current
+  
+  // Get all available storage volumes
+  val storageVolumes = remember(isOpen) {
+    StorageScanUtils.getAllStorageVolumes(context)
+  }
+  
+  // If there's only one storage volume, start there directly
+  // Otherwise, start at storage root view to show all volumes
+  var selectedPath by remember(isOpen, storageVolumes) {
+    val initialPath = if (storageVolumes.size == 1) {
+      StorageScanUtils.getVolumePath(storageVolumes.first())
+    } else {
+      null // Show storage root with all volumes
+    }
+    mutableStateOf(initialPath)
+  }
+
+  // Determine what to show based on selectedPath
+  val showStorageRoot = selectedPath == null
+  
+  val currentDir = remember(selectedPath) { 
+    selectedPath?.let { File(it) }
+  }
+  
+  // Get folders and allowed files
+  val (folders, files) = remember(selectedPath) {
+    if (showStorageRoot) {
+      Pair(emptyList<File>(), emptyList<File>())
+    } else {
+      val allFiles = currentDir?.listFiles { file -> !file.name.startsWith(".") } ?: emptyArray()
+      val dirs = allFiles.filter { it.isDirectory }.sortedBy { it.name.lowercase() }
+      val filteredFiles = allFiles.filter { file -> 
+          !file.isDirectory && allowedExtensions.any { ext -> file.name.endsWith(ext, ignoreCase = true) } 
+      }.sortedBy { it.name.lowercase() }
+      Pair(dirs, filteredFiles)
+    }
+  }
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    properties = DialogProperties(usePlatformDefaultWidth = false),
+    title = {
+      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                  text = "Select Subtitle",
+                  style = MaterialTheme.typography.headlineMedium,
+                  fontWeight = FontWeight.Bold,
+                )
+                Text(
+                  text = selectedPath ?: "Select a storage location",
+                  style = MaterialTheme.typography.bodyMedium,
+                  fontWeight = FontWeight.Medium,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+                  maxLines = 1,
+                  overflow = TextOverflow.Ellipsis,
+                  modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+
+            // Navigation Buttons in Title
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                 if (selectedPath != null) {
+                    FilledTonalIconButton(
+                      onClick = {
+                        val parent = currentDir?.parent
+                        selectedPath = parent
+                      },
+                      modifier = Modifier.size(40.dp),
+                      colors = IconButtonDefaults.filledTonalIconButtonColors(
+                          containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                          contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                      )
+                    ) {
+                      Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", modifier = Modifier.size(24.dp))
+                    }
+                  }
+
+                  FilledTonalIconButton(
+                    onClick = {
+                      selectedPath = Environment.getExternalStorageDirectory().absolutePath
+                    },
+                    modifier = Modifier.size(40.dp),
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                          containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                          contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                      )
+                  ) {
+                    Icon(Icons.Default.Home, "Home", modifier = Modifier.size(24.dp))
+                  }
+
+                  FilledTonalIconButton(
+                    onClick = onSystemPickerRequest,
+                    modifier = Modifier.size(40.dp),
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                  ) {
+                    Icon(Icons.Default.DriveFolderUpload, "System Picker", modifier = Modifier.size(24.dp))
+                  }
+            }
+        }
+      }
+    },
+    text = {
+      Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        // Folder/Volume/File list
+        LazyColumn(
+          modifier =
+            Modifier
+              .fillMaxWidth()
+              .height(400.dp), // Reverted to reasonable height
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          if (showStorageRoot) {
+            // Show storage volumes
+            items(storageVolumes) { volume ->
+              val volumePath = StorageScanUtils.getVolumePath(volume)
+              if (volumePath != null) {
+                StorageVolumeItem(
+                  context = context,
+                  volume = volume,
+                  volumePath = volumePath,
+                  onClick = { selectedPath = volumePath },
+                )
+              }
+            }
+            if (storageVolumes.isEmpty()) {
+              item {
+                 Text("No storage devices found", modifier = Modifier.padding(16.dp))
+              }
+            }
+          } else {
+            // Show folders
+            items(folders) { folder ->
+              FolderItem(
+                folder = folder,
+                onClick = { selectedPath = folder.absolutePath },
+              )
+            }
+            // Show files
+            items(files) { file ->
+                FileItem(
+                    file = file,
+                    onClick = { onFileSelected(file.absolutePath) }
+                )
+            }
+            if (folders.isEmpty() && files.isEmpty()) {
+              item {
+                 Text("No folders or supported files", modifier = Modifier.padding(16.dp))
+              }
+            }
+          }
+        }
+      }
+    },
+    confirmButton = {}, // No explicit confirm button needed for file selection, simple click is enough
+    dismissButton = {
+      TextButton(
+        onClick = onDismiss,
+        shape = MaterialTheme.shapes.extraLarge,
+      ) {
+        Text("Cancel", fontWeight = FontWeight.Medium)
+      }
+    },
+    containerColor = MaterialTheme.colorScheme.surface,
+    tonalElevation = 6.dp,
+    shape = MaterialTheme.shapes.extraLarge,
+    modifier = modifier.fillMaxWidth(0.50f),
+  )
+}
+
+@Composable
+private fun StorageVolumeItem(
+  context: Context,
+  volume: android.os.storage.StorageVolume,
+  volumePath: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val description = volume.getDescription(context)
+  val isPrimary = volume.isPrimary
+  val isRemovable = volume.isRemovable
+  
+  val icon = when {
+    isPrimary -> Icons.Default.Home
+    isRemovable && volumePath.contains("usb", ignoreCase = true) -> Icons.Default.Usb
+    isRemovable -> Icons.Default.SdCard
+    else -> Icons.Default.Folder
+  }
+  
+  Row(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clickable(onClick = onClick)
+        .padding(horizontal = 12.dp, vertical = 12.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      imageVector = icon,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.size(32.dp),
+    )
+    Column(
+      verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+      Text(
+        text = description,
+        style = MaterialTheme.typography.bodyLarge,
+        fontWeight = FontWeight.Bold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+      Text(
+        text = volumePath,
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Medium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+  }
+}
+
+@Composable
+private fun FolderItem(
+  folder: File,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clickable(onClick = onClick)
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      imageVector = Icons.Default.Folder,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.size(28.dp),
+    )
+    Text(
+      text = folder.name,
+      style = MaterialTheme.typography.bodyLarge,
+      fontWeight = FontWeight.Medium,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }
+}
+
+@Composable
+private fun FileItem(
+  file: File,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clickable(onClick = onClick)
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      imageVector = Icons.AutoMirrored.Filled.InsertDriveFile,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.secondary,
+      modifier = Modifier.size(28.dp),
+    )
+    Text(
+      text = file.name,
+      style = MaterialTheme.typography.bodyLarge,
+      fontWeight = FontWeight.Normal,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerSheets.kt
@@ -27,6 +27,9 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import org.koin.compose.koinInject
 import androidx.compose.runtime.collectAsState as composeCollectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 
 @Composable
 fun PlayerSheets(
@@ -75,22 +78,40 @@ fun PlayerSheets(
           if (it == null) return@rememberLauncherForActivityResult
           onAddSubtitle(it)
         }
+
+      var showFilePicker by remember { mutableStateOf(false) }
+
+      if (showFilePicker) {
+          app.marlboroadvance.mpvex.ui.browser.dialogs.FilePickerDialog(
+              isOpen = true,
+              onDismiss = { showFilePicker = false },
+              onFileSelected = { path ->
+                  showFilePicker = false
+                   onAddSubtitle(Uri.parse("file://$path"))
+              },
+              onSystemPickerRequest = {
+                  showFilePicker = false
+                  subtitlesPicker.launch(
+                    arrayOf(
+                      "text/plain",
+                      "text/srt",
+                      "text/vtt",
+                      "application/x-subrip",
+                      "application/x-subtitle",
+                      "text/x-ssa",
+                      "*/*",
+                    ),
+                  )
+              }
+          )
+      }
+
       SubtitlesSheet(
         tracks = subtitles.toImmutableList(),
         onToggleSubtitle = onToggleSubtitle,
         isSubtitleSelected = isSubtitleSelected,
         onAddSubtitle = {
-          subtitlesPicker.launch(
-            arrayOf(
-              "text/plain",
-              "text/srt",
-              "text/vtt",
-              "application/x-subrip",
-              "application/x-subtitle",
-              "text/x-ssa",
-              "*/*", // Fallback for systems that don't recognize subtitle MIME types
-            ),
-          )
+             showFilePicker = true
         },
         onRemoveSubtitle = onRemoveSubtitle,
         onOpenSubtitleSettings = { onOpenPanel(Panels.SubtitleSettings) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
@@ -142,6 +142,25 @@ object AppearancePreferencesScreen : Screen {
 
                     item {
                         PreferenceCard {
+                            val useFloatingNavigation by preferences.useFloatingNavigation.collectAsState()
+                            SwitchPreference(
+                                value = useFloatingNavigation,
+                                onValueChange = { preferences.useFloatingNavigation.set(it) },
+                                title = {
+                                    Text(
+                                        text = "Use Floating Navigation",
+                                    )
+                                },
+                                summary = {
+                                    Text(
+                                        text = "Use the modern floating style for navigation bars",
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                }
+                            )
+
+                            PreferenceDivider()
+
                             val unlimitedNameLines by preferences.unlimitedNameLines.collectAsState()
                             SwitchPreference(
                                 value = unlimitedNameLines,


### PR DESCRIPTION
Added a "Floating Navigation" toggle in Settings -> Appearance.

Enabled (Default): Main Navigation and Selection Bar use a floating style with rounded corners (Pixel-like).
Disabled: Reverts to the standard full-width navigation bar.
Consistency: Both bars share the same height , padding, and animations.
Also added Folder picker for External Subtitle selection insted of Oprning it in another folder for selection

![Screenshot_20260120_201822](https://github.com/user-attachments/assets/ab965b2d-5945-4b63-a518-e671a45abd9e)
![Screenshot_20260120_201825](https://github.com/user-attachments/assets/04072ef7-f771-4c8e-801c-69bb892cd035)
![Screenshot_20260120_201850](https://github.com/user-attachments/assets/db805647-4b91-40ef-be3a-cda5d1704952)
![Screenshot_20260120_201859](https://github.com/user-attachments/assets/809298d6-63de-4e29-a37f-2b01def077f0)
![Screenshot_20260120_201906](https://github.com/user-attachments/assets/9b83ebda-76ee-4a38-af56-24c9db2fb083)
![Screenshot_20260120_210631](https://github.com/user-attachments/assets/42ea5769-1cdf-4dae-bf3e-809f52dbdf2c)
