### PR TITLE
Fix Jitter, Overlay Panels, and Brkoen Theme Fix for 2x Indicator (light mode)

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MPVView.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MPVView.kt
@@ -277,7 +277,8 @@ class MPVView(
     val borderSize = subtitlesPreferences.borderSize.get().toString()
     val borderStyle = subtitlesPreferences.borderStyle.get().value
     val shadowOffset = subtitlesPreferences.shadowOffset.get().toString()
-    val subPos = subtitlesPreferences.subPos.get().toString()
+    val subPosInt = subtitlesPreferences.subPos.get()
+    val subPos = subPosInt.toString()
     val subScale = subtitlesPreferences.subScale.get().toString()
 
     MPVLib.setOptionString("sub-font-size", fontSize)
@@ -293,6 +294,8 @@ class MPVView(
     MPVLib.setOptionString("sub-scale", subScale)
     MPVLib.setOptionString("sub-pos", subPos)
     
+    val secondarySubPos = if (subPosInt >= 50) "5" else "95"
+
     MPVLib.setOptionString("secondary-sub-font-size", fontSize)
     MPVLib.setOptionString("secondary-sub-bold", bold)
     MPVLib.setOptionString("secondary-sub-italic", italic)
@@ -304,7 +307,7 @@ class MPVView(
     MPVLib.setOptionString("secondary-sub-border-style", borderStyle)
     MPVLib.setOptionString("secondary-sub-shadow-offset", shadowOffset)
     MPVLib.setOptionString("secondary-sub-scale", subScale)
-    MPVLib.setOptionString("secondary-sub-pos", subPos)
+    MPVLib.setOptionString("secondary-sub-pos", secondarySubPos)
 
     val scaleByWindow = if (subtitlesPreferences.scaleByWindow.get()) "yes" else "no"
     MPVLib.setOptionString("sub-scale-by-window", scaleByWindow)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -416,7 +417,7 @@ fun PlayerControls(
           modifier =
             Modifier.constrainAs(playerUpdates) {
               linkTo(parent.start, parent.end)
-              linkTo(parent.top, parent.bottom, bias = 0.2f)
+              top.linkTo(parent.top, 64.dp)
             },
         ) {
           when (currentPlayerUpdate) {
@@ -459,12 +460,18 @@ fun PlayerControls(
 
             is PlayerUpdates.VideoZoom -> {
               val zoomPercentage = (videoZoom * 100).toInt()
-              TextPlayerUpdate("Zoom: $zoomPercentage%")
+              TextPlayerUpdate(
+                text = String.format("Zoom:%3d%%", zoomPercentage), 
+                modifier = Modifier.width(160.dp),
+              )
             }
 
             is PlayerUpdates.HorizontalSeek -> {
               val seekUpdate = currentPlayerUpdate as PlayerUpdates.HorizontalSeek
-              TextPlayerUpdate("${seekUpdate.currentTime} [ ${seekUpdate.seekDelta} ]")
+              TextPlayerUpdate(
+                text = "${seekUpdate.currentTime} [${seekUpdate.seekDelta}]",
+                modifier = Modifier.width(220.dp),
+              )
             }
 
             is PlayerUpdates.RepeatMode -> {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/PlayerUpdates.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/PlayerUpdates.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.marlboroadvance.mpvex.R
 import app.marlboroadvance.mpvex.ui.theme.spacing
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.foundation.layout.widthIn
 
 @Composable
 fun PlayerUpdate(
@@ -55,13 +58,20 @@ fun PlayerUpdate(
   }
 }
 
+
 @Composable
 fun TextPlayerUpdate(
   text: String,
   modifier: Modifier = Modifier,
 ) {
   PlayerUpdate(modifier) {
-    Text(text)
+    Text(
+      text = text,
+      fontFamily = FontFamily.Monospace,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
   }
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
@@ -516,7 +516,7 @@ fun VideoTimer(
         )
         .wrapContentHeight(Alignment.CenterVertically),
     text = Utils.prettyTime(value.toInt(), isInverted),
-    color = Color.White,
+    color = MaterialTheme.colorScheme.onSurface,
     textAlign = TextAlign.Center,
   )
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/SpeedControlSlider.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/SpeedControlSlider.kt
@@ -212,6 +212,7 @@ fun CompactSpeedIndicator(
       imageVector = Icons.Filled.FastForward,
       contentDescription = null,
       modifier = Modifier.size(16.dp),
+      tint = MaterialTheme.colorScheme.onSurface 
     )
     Text(
       text = "${currentSpeed.format()}x",
@@ -219,6 +220,7 @@ fun CompactSpeedIndicator(
       fontWeight = FontWeight.Bold,
       style = MaterialTheme.typography.bodyLarge,
       modifier = Modifier.padding(start = 4.dp),
+      color = MaterialTheme.colorScheme.onSurface // Explicitly set color
     )
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/AudioDelayPanel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/AudioDelayPanel.kt
@@ -40,15 +40,8 @@ fun AudioDelayPanel(
   modifier: Modifier = Modifier,
 ) {
   val preferences = koinInject<AudioPreferences>()
-
-  ConstraintLayout(
-    modifier =
-      modifier
-        .fillMaxSize()
-        .padding(MaterialTheme.spacing.medium),
-  ) {
-    val delayControlCard = createRef()
-
+  
+  DraggablePanel(modifier = modifier) {
     val delay by MPVLib.propDouble["audio-delay"].collectAsState()
     val delayFloat by remember { derivedStateOf { (delay ?: 0.0).toFloat() } }
 
@@ -62,13 +55,28 @@ fun AudioDelayPanel(
       onReset = { MPVLib.setPropertyDouble("audio-delay", 0.0) },
       title = { AudioDelayCardTitle(onClose = onDismissRequest) },
       delayType = DelayType.Audio,
-      modifier =
-        Modifier.constrainAs(delayControlCard) {
-          top.linkTo(parent.top)
-          end.linkTo(parent.end)
-        },
     )
   }
+}
+
+// Ensure the AudioDelayPanel also uses the content version as DraggablePanel wraps it
+@Composable
+fun DelayCard(
+    delay: Float,
+    onDelayChange: (Float) -> Unit,
+    onApply: () -> Unit,
+    onReset: () -> Unit,
+    title: @Composable () -> Unit,
+    delayType: DelayType,
+) {
+    DelayCardContent(
+        delay = delay,
+        onDelayChange = onDelayChange,
+        onApply = onApply,
+        onReset = onReset,
+        title = title,
+        delayType = delayType
+    )
 }
 
 @Composable

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/DraggablePanel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/DraggablePanel.kt
@@ -1,0 +1,93 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package app.marlboroadvance.mpvex.ui.player.controls.components.panels
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import app.marlboroadvance.mpvex.ui.player.controls.panelCardsColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+
+import kotlin.math.roundToInt
+
+@Composable
+fun DraggablePanel(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var panelWidth by remember { mutableIntStateOf(0) }
+    
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.CenterEnd // Default to Right End
+    ) {
+        val density = LocalDensity.current
+        val parentWidthPx = with(density) { maxWidth.toPx() }
+        
+        // Calculate bounds for horizontal drag
+        // Panel is aligned to CenterEnd (Right), so offset 0 is the default rightmost position.
+        val freeSpace = (parentWidthPx - panelWidth).coerceAtLeast(0f)
+        val maxOffset = 0f
+        val minOffset = -freeSpace
+
+        val colors = panelCardsColors()
+        Surface(
+            modifier = Modifier
+                .offset { IntOffset(offsetX.roundToInt(), 0) }
+                .pointerInput(maxOffset, minOffset) { // Restart detector if bounds change
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val newOffset = offsetX + dragAmount.x
+                        offsetX = newOffset.coerceIn(minOffset, maxOffset)
+                    }
+                }
+                .onSizeChanged { panelWidth = it.width }
+                .widthIn(max = 380.dp),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = colors.containerColor,
+            contentColor = colors.contentColor,
+            tonalElevation = 0.dp,
+        ) {
+            Column {
+                 // Drag Indicator
+                 Box(
+                     modifier = Modifier
+                         .padding(top = 12.dp, bottom = 4.dp)
+                         .width(32.dp)
+                         .height(4.dp)
+                         .align(Alignment.CenterHorizontally)
+                         .background(
+                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                             shape = RoundedCornerShape(2.dp)
+                         )
+                 )
+                
+                content()
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleDelayPanel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleDelayPanel.kt
@@ -63,19 +63,14 @@ fun SubtitleDelayPanel(
 ) {
   val preferences = koinInject<SubtitlesPreferences>()
 
-  ConstraintLayout(
-    modifier =
-      modifier
-        .fillMaxSize()
-        .padding(MaterialTheme.spacing.medium),
-  ) {
-    val delayControlCard = createRef()
-
+  DraggablePanel(modifier = modifier) {
     val delay by MPVLib.propDouble["sub-delay"].collectAsState()
     val delayFloat by remember { derivedStateOf { (delay ?: 0.0).toFloat() } }
     val speed by MPVLib.propDouble["sub-speed"].collectAsState()
     val speedFloat by remember { derivedStateOf { (speed ?: 1.0).toFloat() } }
-    SubtitleDelayCard(
+    
+    // We unwrap the card content here because DraggablePanel already provides the card
+    SubtitleDelayCardContent(
       delay = delayFloat,
       onDelayChange = {
         MPVLib.setPropertyDouble("sub-delay", it.toDouble())
@@ -92,17 +87,13 @@ fun SubtitleDelayPanel(
         MPVLib.setPropertyDouble("sub-speed", preferences.defaultSubSpeed.get().toDouble())
       },
       onClose = onDismissRequest,
-      modifier =
-        Modifier.constrainAs(delayControlCard) {
-          top.linkTo(parent.top)
-          end.linkTo(parent.end)
-        },
     )
   }
 }
 
+// Extracted content to avoid nested cards since DraggablePanel has a Card
 @Composable
-fun SubtitleDelayCard(
+private fun SubtitleDelayCardContent(
   delay: Float,
   onDelayChange: (Float) -> Unit,
   speed: Float,
@@ -110,166 +101,140 @@ fun SubtitleDelayCard(
   onApply: () -> Unit,
   onReset: () -> Unit,
   onClose: () -> Unit,
-  modifier: Modifier = Modifier,
 ) {
-  DelayCard(
-    delay = delay,
-    onDelayChange = onDelayChange,
-    onApply = onApply,
-    onReset = onReset,
-    title = {
-      SubtitleDelayTitle(onClose = onClose)
-    },
-    extraSettings = {
-      OutlinedNumericChooser(
-        label = { Text(stringResource(R.string.player_sheets_sub_delay_card_speed)) },
-        value = speed,
-        onChange = onSpeedChange,
-        max = 10f,
-        step = 0.01f,
-        min = 0.1f,
-        increaseIcon = Icons.Filled.Add,
-        decreaseIcon = Icons.Filled.Remove,
-        valueFormatter = { "%.2f".format(it) }
-      )
-    },
-    delayType = DelayType.Subtitle,
-    modifier = modifier,
-  )
+    DelayCardContent(
+      delay = delay,
+      onDelayChange = onDelayChange,
+      onApply = onApply,
+      onReset = onReset,
+      title = { SubtitleDelayTitle(onClose = onClose) },
+      delayType = DelayType.Subtitle,
+      extraSettings = {
+        OutlinedNumericChooser(
+          label = { Text(stringResource(R.string.player_sheets_sub_delay_card_speed)) },
+          value = speed,
+          onChange = onSpeedChange,
+          max = 10f,
+          step = 0.01f,
+          min = 0.1f,
+          increaseIcon = Icons.Filled.Add,
+          decreaseIcon = Icons.Filled.Remove,
+          valueFormatter = { "%.2f".format(it) }
+        )
+      }
+    )
 }
 
-@Suppress("LambdaParameterInRestartableEffect") // Intentional
+@Suppress("LambdaParameterInRestartableEffect") 
 @Composable
-fun DelayCard(
+fun DelayCardContent( // Renamed from DelayCard and removed the Card wrapper
   delay: Float,
   onDelayChange: (Float) -> Unit,
   onApply: () -> Unit,
   onReset: () -> Unit,
   title: @Composable () -> Unit,
   delayType: DelayType,
-  modifier: Modifier = Modifier,
   extraSettings: @Composable ColumnScope.() -> Unit = {},
 ) {
-  Card(
-    modifier =
-      modifier
-        .widthIn(max = CARDS_MAX_WIDTH)
-        .animateContentSize(),
-    colors = panelCardsColors(),
-    shape = MaterialTheme.shapes.large,
-    border = androidx.compose.foundation.BorderStroke(
-      1.dp,
-      MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
-    ),
-    elevation = androidx.compose.material3.CardDefaults.cardElevation(
-      defaultElevation = 0.dp,
-      pressedElevation = 0.dp,
-      focusedElevation = 0.dp,
-      hoveredElevation = 0.dp,
-      draggedElevation = 0.dp,
-      disabledElevation = 0.dp,
-    ),
-  ) {
     Column(
-      Modifier
-        .verticalScroll(rememberScrollState())
-        .padding(MaterialTheme.spacing.medium),
-      verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
+       Modifier
+         .verticalScroll(rememberScrollState())
+         .padding(MaterialTheme.spacing.medium),
+       verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
     ) {
-      title()
-      OutlinedNumericChooser(
-        label = { Text(stringResource(R.string.player_sheets_sub_delay_card_delay)) },
-        value = delay,
-        onChange = onDelayChange,
-        step = 0.1f,
-        min = Float.NEGATIVE_INFINITY,
-        max = Float.POSITIVE_INFINITY,
-        suffix = { Text("s") },
-        increaseIcon = Icons.Filled.Add,
-        decreaseIcon = Icons.Filled.Remove,
-        valueFormatter = { "%.1f".format(it) }
-      )
-      Column(
-        modifier = Modifier.animateContentSize(),
-      ) { extraSettings() }
-      // true (heard -> spotted), false (spotted -> heard)
-      var isDirectionPositive by remember { mutableStateOf<Boolean?>(null) }
-      Row(
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
-      ) {
-        var timerStart by remember { mutableStateOf<Long?>(null) }
-        var finalDelay by remember { mutableStateOf(delay) }
-        LaunchedEffect(isDirectionPositive) {
-          if (isDirectionPositive == null) {
-            onDelayChange(finalDelay)
-            return@LaunchedEffect
-          }
-          finalDelay = delay
-          val startTime = System.currentTimeMillis()
-          timerStart = startTime
-          val startingDelay: Float = finalDelay
-          while (isDirectionPositive != null && timerStart != null) {
-            val elapsed = System.currentTimeMillis() - startTime
-            val direction = isDirectionPositive ?: break
-            finalDelay = startingDelay + (if (direction) elapsed / 1000f else -elapsed / 1000f)
-            // Arbitrary delay of 20ms
-            delay(20)
-          }
-        }
-        Button(
-          onClick = {
-            isDirectionPositive = if (isDirectionPositive == null) delayType == DelayType.Audio else null
-          },
-          modifier = Modifier.weight(1f),
-          enabled = isDirectionPositive != (delayType == DelayType.Audio),
-        ) {
-          Text(
-            stringResource(
-              if (delayType == DelayType.Audio) {
-                R.string.player_sheets_sub_delay_audio_sound_heard
-              } else {
-                R.string.player_sheets_sub_delay_subtitle_voice_heard
-              },
-            ),
-          )
-        }
-        Button(
-          onClick = {
-            isDirectionPositive = if (isDirectionPositive == null) delayType != DelayType.Audio else null
-          },
-          modifier = Modifier.weight(1f),
-          enabled = isDirectionPositive != (delayType == DelayType.Subtitle),
-        ) {
-          Text(
-            stringResource(
-              if (delayType == DelayType.Audio) {
-                R.string.player_sheets_sub_delay_sound_sound_spotted
-              } else {
-                R.string.player_sheets_sub_delay_subtitle_text_seen
-              },
-            ),
-          )
-        }
-      }
-      Row(
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
-      ) {
-        Button(
-          onClick = onApply,
-          modifier = Modifier.weight(1f),
-          enabled = isDirectionPositive == null,
-        ) {
-          Text(stringResource(R.string.player_sheets_delay_set_as_default))
-        }
-        FilledIconButton(
-          onClick = onReset,
-          enabled = isDirectionPositive == null,
-        ) {
-          Icon(Icons.Default.Refresh, null)
-        }
-      }
+       title()
+       OutlinedNumericChooser(
+         label = { Text(stringResource(R.string.player_sheets_sub_delay_card_delay)) },
+         value = delay,
+         onChange = onDelayChange,
+         step = 0.1f,
+         min = Float.NEGATIVE_INFINITY,
+         max = Float.POSITIVE_INFINITY,
+         suffix = { Text("s") },
+         increaseIcon = Icons.Filled.Add,
+         decreaseIcon = Icons.Filled.Remove,
+         valueFormatter = { "%.1f".format(it) }
+       )
+       Column(
+         modifier = Modifier.animateContentSize(),
+       ) { extraSettings() }
+       // true (heard -> spotted), false (spotted -> heard)
+       var isDirectionPositive by remember { mutableStateOf<Boolean?>(null) }
+       Row(
+         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
+       ) {
+         var timerStart by remember { mutableStateOf<Long?>(null) }
+         var finalDelay by remember { mutableStateOf(delay) }
+         LaunchedEffect(isDirectionPositive) {
+           if (isDirectionPositive == null) {
+             onDelayChange(finalDelay)
+             return@LaunchedEffect
+           }
+           finalDelay = delay
+           val startTime = System.currentTimeMillis()
+           timerStart = startTime
+           val startingDelay: Float = finalDelay
+           while (isDirectionPositive != null && timerStart != null) {
+             val elapsed = System.currentTimeMillis() - startTime
+             val direction = isDirectionPositive ?: break
+             finalDelay = startingDelay + (if (direction) elapsed / 1000f else -elapsed / 1000f)
+             // Arbitrary delay of 20ms
+             delay(20)
+           }
+         }
+         Button(
+           onClick = {
+             isDirectionPositive = if (isDirectionPositive == null) delayType == DelayType.Audio else null
+           },
+           modifier = Modifier.weight(1f),
+           enabled = isDirectionPositive != (delayType == DelayType.Audio),
+         ) {
+           Text(
+             stringResource(
+               if (delayType == DelayType.Audio) {
+                 R.string.player_sheets_sub_delay_audio_sound_heard
+               } else {
+                 R.string.player_sheets_sub_delay_subtitle_voice_heard
+               },
+             ),
+           )
+         }
+         Button(
+           onClick = {
+             isDirectionPositive = if (isDirectionPositive == null) delayType != DelayType.Audio else null
+           },
+           modifier = Modifier.weight(1f),
+           enabled = isDirectionPositive != (delayType == DelayType.Subtitle),
+         ) {
+           Text(
+             stringResource(
+               if (delayType == DelayType.Audio) {
+                 R.string.player_sheets_sub_delay_sound_sound_spotted
+               } else {
+                 R.string.player_sheets_sub_delay_subtitle_text_seen
+               },
+             ),
+           )
+         }
+       }
+       Row(
+         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
+       ) {
+         Button(
+           onClick = onApply,
+           modifier = Modifier.weight(1f),
+           enabled = isDirectionPositive == null,
+         ) {
+           Text(stringResource(R.string.player_sheets_delay_set_as_default))
+         }
+         FilledIconButton(
+           onClick = onReset,
+           enabled = isDirectionPositive == null,
+         ) {
+           Icon(Icons.Default.Refresh, null)
+         }
+       }
     }
-  }
 }
 
 @Composable

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleSettingsPanel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleSettingsPanel.kt
@@ -34,37 +34,7 @@ fun SubtitleSettingsPanel(
   onDismissRequest: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  ConstraintLayout(
-    modifier =
-      modifier
-        .fillMaxSize()
-        .padding(MaterialTheme.spacing.medium),
-  ) {
-    val settingsCard = createRef()
-
-    Card(
-      modifier =
-        Modifier
-          .constrainAs(settingsCard) {
-            top.linkTo(parent.top)
-            end.linkTo(parent.end)
-          }
-          .widthIn(max = CARDS_MAX_WIDTH),
-      colors = panelCardsColors(),
-      shape = MaterialTheme.shapes.large,
-      border = androidx.compose.foundation.BorderStroke(
-        1.dp,
-        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
-      ),
-      elevation = androidx.compose.material3.CardDefaults.cardElevation(
-        defaultElevation = 0.dp,
-        pressedElevation = 0.dp,
-        focusedElevation = 0.dp,
-        hoveredElevation = 0.dp,
-        draggedElevation = 0.dp,
-        disabledElevation = 0.dp,
-      ),
-    ) {
+  DraggablePanel(modifier = modifier) {
       Column(
         Modifier
           .verticalScroll(rememberScrollState())
@@ -89,6 +59,5 @@ fun SubtitleSettingsPanel(
         SubtitleSettingsColorsCard()
         SubtitlesMiscellaneousCard()
       }
-    }
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/VideoSettingsPanel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/VideoSettingsPanel.kt
@@ -34,37 +34,7 @@ fun VideoSettingsPanel(
   onDismissRequest: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  ConstraintLayout(
-    modifier =
-      modifier
-        .fillMaxSize()
-        .padding(MaterialTheme.spacing.medium),
-  ) {
-    val settingsCard = createRef()
-
-    Card(
-      modifier =
-        Modifier
-          .constrainAs(settingsCard) {
-            top.linkTo(parent.top)
-            end.linkTo(parent.end)
-          }
-          .widthIn(max = CARDS_MAX_WIDTH),
-      colors = panelCardsColors(),
-      shape = MaterialTheme.shapes.large,
-      border = androidx.compose.foundation.BorderStroke(
-        1.dp,
-        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
-      ),
-      elevation = androidx.compose.material3.CardDefaults.cardElevation(
-        defaultElevation = 0.dp,
-        pressedElevation = 0.dp,
-        focusedElevation = 0.dp,
-        hoveredElevation = 0.dp,
-        draggedElevation = 0.dp,
-        disabledElevation = 0.dp,
-      ),
-    ) {
+  DraggablePanel(modifier = modifier) {
       Column(
         Modifier
           .verticalScroll(rememberScrollState())
@@ -89,6 +59,5 @@ fun VideoSettingsPanel(
         VideoSettingsFiltersCard()
         VideoSettingsDebandCard()
       }
-    }
   }
 }


### PR DESCRIPTION
- **Jitter Fix**:
  - Zoom indicator now uses a fixed width (160dp) and constant string format (%3d%%) to prevent resizing.
  - Seek timer uses fixed width (220dp).
  - Switched to Monospace Bold font for stability.
  
- **Overlay Panels**:
  - Made Overlay panels Draggable, so video obstruction of seek doesn happen and also Improved the Code for Handeling future draggable panels

- **Theming**:
  - CompactSpeedIndicator (2x overlay) and VideoTimer (Seekbar) now use MaterialTheme.colorScheme.onSurface instead of hardcoded white, fixing visibility in light mode.
  
- **2 Subtitles Selection Position**:
  - Made Changes to Subtitle position of second subtitle if the second one is selected then it hsould not overlap on each other #463 
  