### PR TITLE
removed grid mode selection spacing between two folder/video

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/FolderCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/FolderCard.kt
@@ -173,6 +173,7 @@ fun FolderCard(
           style = MaterialTheme.typography.titleSmall,
           color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
           maxLines = maxLines,
+          minLines = 2,
           overflow = TextOverflow. Ellipsis,
           textAlign = androidx.compose.ui. text.style.TextAlign.Center,
         )

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/VideoCard.kt
@@ -278,6 +278,7 @@ fun VideoCard(
             MaterialTheme.colorScheme.onSurface
           },
           maxLines = maxLines,
+          minLines = 2,
           overflow = TextOverflow. Ellipsis,
           textAlign = if (useFolderNameStyle) {
             TextAlign.Center

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -897,8 +897,6 @@ private fun GridContent(
         end = 8.dp,
         bottom = navigationBarHeight
       ),
-      horizontalArrangement = Arrangement.spacedBy(4.dp),
-      verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
       items(folders.size) { index ->
         val folder = folders[index]

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -688,8 +688,6 @@ private fun VideoListContent(
                   end = 8.dp,
                   bottom = if (showFloatingBottomBar) 88.dp else 16.dp
                 ),
-              horizontalArrangement = Arrangement.spacedBy(8.dp),
-              verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
             items(
               count = videosWithInfo.size,


### PR DESCRIPTION
now the spacing is similar to the list

<img width="1080" height="2424" alt="Screenshot_20260219-232134" src="https://github.com/user-attachments/assets/faa79ec3-3d4f-47d4-8a64-90697deaec51" />
