### PR TITLE
fix(ambient): ensure seamless transition and persistent state across playbacks

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -85,4 +85,7 @@ class PlayerPreferences(
   val ambientEdgeSmooth = preferenceStore.getFloat("ambient_edge_smooth", 0.02f)
   val ambientFadeCurve = preferenceStore.getFloat("ambient_fade_curve", 1.5f)
   val ambientOpacity = preferenceStore.getFloat("ambient_opacity", 1.0f)
+  // NEW: Ambient Mode persistant value added by @Chinna95P
+  val isAmbientEnabled = preferenceStore.getBoolean("ambient_enabled", false)
+  
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -185,6 +185,18 @@ class PlayerViewModel(
         val dur = MPVLib.getPropertyDouble("duration")
         if (dur != null && dur > 0) {
             _preciseDuration.value = dur.toFloat()
+            
+            // --- AMBIENT FIX: Adapt shader to new file dimensions by @Chinna95P ---
+            if (_isAmbientEnabled.value) {
+                lastAmbientScaleX = -1.0 // Force a complete shader rewrite
+                ambientDebounceJob?.cancel()
+                ambientDebounceJob = viewModelScope.launch {
+                    // Slight delay ensures MPV's video-params (w/h/crop) are fully populated
+                    delay(250) 
+                    updateAmbientStretch()
+                }
+            }
+            // --------------------------------------------------------
         }
       }
     }
@@ -787,6 +799,33 @@ class PlayerViewModel(
       _externalSubtitles.clear()
       // Scan for previously downloaded/added subtitles
       scanLocalSubtitles(mediaTitle)
+
+      // --- ADDED: Reset visual states for the new file for Ambient Mode Function by @Chinna95P ---
+      
+      // 1. Reset Aspect Ratio UI state and MPV properties to "Fit"
+      _videoAspect.value = VideoAspect.Fit
+      _currentAspectRatio.value = -1.0
+      runCatching {
+        MPVLib.setPropertyDouble("panscan", 0.0)
+        MPVLib.setPropertyDouble("video-aspect-override", -1.0)
+      }
+
+      // 2. Reset Video Zoom
+      if (_videoZoom.value != 0f) {
+          _videoZoom.value = 0f
+          runCatching { MPVLib.setPropertyDouble("video-zoom", 0.0) }
+      }
+
+      // 3. Reset Video Pan
+      if (_videoPanX.value != 0f || _videoPanY.value != 0f) {
+          _videoPanX.value = 0f
+          _videoPanY.value = 0f
+          runCatching {
+              MPVLib.setPropertyDouble("video-pan-x", 0.0)
+              MPVLib.setPropertyDouble("video-pan-y", 0.0)
+          }
+      }
+      // ---------------------------------------------------
     }
   }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -2233,8 +2233,14 @@ class PlayerViewModel(
   /** Resets ambient mode to OFF when a new video file is loaded. */
   fun resetAmbientMode() {
     if (!_isAmbientEnabled.value) return
-    _isAmbientEnabled.value = false
+    
+    // Ambient Mode Persistent Fix for Next/Previous files by @Chinna95P
+    // DO NOT set _isAmbientEnabled.value = false
+    // Just temporarily remove the old shader and reset the scale 
+    // so the new video starts with a clean slate before recalculating.
     disableAmbientShader()
+    lastAmbientScaleX = -1.0
+    lastAmbientScaleY = -1.0
   }
 
   /**

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -328,7 +328,8 @@ class PlayerViewModel(
   val isVerticalFlipped: StateFlow<Boolean> = _isVerticalFlipped.asStateFlow()
 
   // ==================== Ambience Mode ======================================
-  private val _isAmbientEnabled = MutableStateFlow(false)
+  // Added Ambient Mode Persistant saved state call by @Chinna95P
+  private val _isAmbientEnabled = MutableStateFlow(playerPreferences.isAmbientEnabled.get())
   val isAmbientEnabled: StateFlow<Boolean> = _isAmbientEnabled.asStateFlow()
 
   private val _ambientBlurSamples = MutableStateFlow(playerPreferences.ambientBlurSamples.get())
@@ -2191,6 +2192,9 @@ class PlayerViewModel(
 
   fun toggleAmbientMode() {
     _isAmbientEnabled.value = !_isAmbientEnabled.value
+
+    // Save the Ambient Mode ON/OFF state permanently to preferences added by @Chinna95P
+    playerPreferences.isAmbientEnabled.set(_isAmbientEnabled.value)
     if (_isAmbientEnabled.value) {
       lastAmbientScaleX = -1.0 // Force rewrite
       updateAmbientStretch()


### PR DESCRIPTION
### Description
This PR addresses edge cases where Ambient Mode and Video Aspect properties incorrectly reset or carry over when transitioning between files (e.g., clicking Next or auto-playing a playlist), and makes Ambient Mode a fully persistent user preference.

### Changes Made:
* **`PlayerPreferences.kt`**: Added `isAmbientEnabled` boolean to allow Ambient Mode to persist across app restarts.
* **`PlayerViewModel.kt`**: 
  * Fixed a bug where keeping Ambient ON during a file transition would apply the previous video's dimension math to the new video. The `duration` observer now forces a recalculation (`lastAmbientScaleX = -1.0`) when a new file loads.
  * Updated `resetAmbientMode()` to clear previous shaders without forcefully toggling the user's ON/OFF preference to `false`, allowing the next video in a playlist to automatically re-blur.
  * Updated `setMediaTitle()` to strictly reset UI states and MPV engine properties for Video Aspect Ratio (forces `Fit`), Video Pan, and Video Zoom. This guarantees every new file starts with a clean visual slate before Ambient shaders are applied.

### Testing
* Tested locally on device via debug APK. 
* Verified Ambient Mode correctly toggles, survives app restarts, and seamlessly adapts to different aspect ratios within the same playlist without visual stretching.