### PR TITLE
feat: add Wyzie API key support for subtitle search

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/SubtitlesPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/SubtitlesPreferences.kt
@@ -52,6 +52,7 @@ class SubtitlesPreferences(
   val wyzieFormats = preferenceStore.getStringSet("wyzie_formats", setOf("srt", "ass"))
   val wyzieEncodings = preferenceStore.getStringSet("wyzie_encodings", setOf("utf-8"))
   val wyzieHearingImpaired = preferenceStore.getBoolean("wyzie_hi", false)
+  val wyzieApiKey = preferenceStore.getString("wyzie_api_key", "")
 }
 
 enum class SubtitleJustification(

--- a/app/src/main/java/app/marlboroadvance/mpvex/repository/wyzie/WyzieSearchRepository.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/repository/wyzie/WyzieSearchRepository.kt
@@ -206,7 +206,7 @@ class WyzieSearchRepository(
     private val json: Json,
     private val preferences: SubtitlesPreferences
 ) {
-    private val baseUrl = "https://sub.wyzie.ru"
+    private val baseUrl = "https://sub.wyzie.io"
 
     suspend fun search(
         query: String,
@@ -306,6 +306,7 @@ class WyzieSearchRepository(
     ): List<WyzieSubtitle> {
         fun encode(s: String) = URLEncoder.encode(s, "UTF-8")
         
+        val apiKey = preferences.wyzieApiKey.get()
         val url = StringBuilder("$baseUrl/search?id=${encode(id)}")
             .apply {
                 if (season != null && episode != null) {
@@ -327,23 +328,26 @@ class WyzieSearchRepository(
 
                 append("&unzip=true")
                 hi?.let { append("&hi=$it") }
+                if (apiKey.isNotBlank()) append("&key=${encode(apiKey)}")
             }.toString()
 
         val request = Request.Builder().url(url).build()
         client.newCall(request).execute().use { response ->
             val responseBodyString = response.body?.string() ?: ""
             if (!response.isSuccessful) {
+                // Invalid or missing API key
+                if (response.code == 401 || response.code == 403) {
+                    throw IOException("Invalid Wyzie API key. Check your key in Settings → Subtitles.")
+                }
                 // Wyzie API returns 400 when no subtitles are found for valid parameters
                 if (response.code == 400 && responseBodyString.contains("No subtitles found", ignoreCase = true)) {
                     return emptyList()
                 }
-                
                 if (response.code == 400 && responseBodyString.contains("season and episode", ignoreCase = true)) {
                     throw IOException("Please select both a Season and an Episode.")
                 }
-                val errorMsg = "Search failed: HTTP ${response.code} for URL: $url | Body: $responseBodyString"
-                Log.e("WyzieSearchRepository", errorMsg)
-                throw IOException(errorMsg)
+                Log.e("WyzieSearchRepository", "Search failed: HTTP ${response.code} | Body: $responseBodyString")
+                throw IOException("Search failed (HTTP ${response.code}). Please try again.")
             }
             return try {
                 json.decodeFromString<List<WyzieSubtitle>>(responseBodyString)
@@ -407,7 +411,9 @@ class WyzieSearchRepository(
 
     suspend fun getTvShowDetails(id: Int): Result<WyzieTvShowDetails> = withContext(Dispatchers.IO) {
         try {
-            val url = "$baseUrl/api/tmdb/tv/$id"
+            val apiKey = preferences.wyzieApiKey.get()
+            val keyParam = if (apiKey.isNotBlank()) "?key=${URLEncoder.encode(apiKey, "UTF-8")}" else ""
+            val url = "$baseUrl/api/tmdb/tv/$id$keyParam"
             val request = Request.Builder().url(url).build()
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) throw IOException("Failed to get TV show details: ${response.code}")
@@ -422,7 +428,9 @@ class WyzieSearchRepository(
 
     suspend fun getSeasonEpisodes(id: Int, season: Int): Result<List<WyzieEpisode>> = withContext(Dispatchers.IO) {
         try {
-            val url = "$baseUrl/api/tmdb/tv/$id/$season"
+            val apiKey = preferences.wyzieApiKey.get()
+            val keyParam = if (apiKey.isNotBlank()) "?key=${URLEncoder.encode(apiKey, "UTF-8")}" else ""
+            val url = "$baseUrl/api/tmdb/tv/$id/$season$keyParam"
             val request = Request.Builder().url(url).build()
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) throw IOException("Failed to get season episodes: ${response.code}")
@@ -436,10 +444,15 @@ class WyzieSearchRepository(
     }
 
     private fun tmdbSearch(query: String): List<WyzieTmdbResult> {
-        val url = "$baseUrl/api/tmdb/search?q=${URLEncoder.encode(query, "UTF-8")}"
+        val apiKey = preferences.wyzieApiKey.get()
+        val keyParam = if (apiKey.isNotBlank()) "&key=${URLEncoder.encode(apiKey, "UTF-8")}" else ""
+        val url = "$baseUrl/api/tmdb/search?q=${URLEncoder.encode(query, "UTF-8")}$keyParam"
         val request = Request.Builder().url(url).build()
         client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) throw IOException("TMDb search failed: ${response.code}")
+            if (response.code == 401 || response.code == 403) {
+                throw IOException("Invalid Wyzie API key. Check your key in Settings → Subtitles.")
+            }
+            if (!response.isSuccessful) throw IOException("Media search failed (HTTP ${response.code}). Please try again.")
             val body = response.body?.string() ?: throw IOException("Empty body")
             return json.decodeFromString<WyzieTmdbResponse>(body).results
         }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -649,7 +649,7 @@ class PlayerViewModel(
           _mediaSearchResults.value = results
         }
         .onFailure {
-          // Silent failure for autocomplete, or optionally show toast(if someone is reading this if u need u can impelmen this in future )
+          // Silent failure for autocomplete
         }
       _isSearchingMedia.value = false
     }
@@ -720,6 +720,10 @@ class PlayerViewModel(
 
   // --- Subtitle Search ---
   fun searchSubtitles(query: String, season: Int? = null, episode: Int? = null, year: String? = null) {
+    if (subtitlesPreferences.wyzieApiKey.get().isBlank()) {
+      showToast("Wyzie API key not set. Go to Settings → Subtitles to add your free key from sub.wyzie.io/redeem")
+      return
+    }
      viewModelScope.launch {
          _isSearchingSub.value = true
          wyzieRepository.search(query, season, episode, year)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerSheets.kt
@@ -124,6 +124,8 @@ fun PlayerSheets(
           )
       }
 
+      val subtitlesPreferencesForApiCheck = koinInject<app.marlboroadvance.mpvex.preferences.SubtitlesPreferences>()
+
       SubtitlesSheet(
         tracks = subtitles.toImmutableList(),
         onToggleSubtitle = onToggleSubtitle,
@@ -132,7 +134,13 @@ fun PlayerSheets(
         onRemoveSubtitle = onRemoveSubtitle,
         onOpenSubtitleSettings = { onOpenPanel(Panels.SubtitleSettings) },
         onOpenSubtitleDelay = { onOpenPanel(Panels.SubtitleDelay) },
-        onOpenOnlineSearch = { onShowSheet(Sheets.OnlineSubtitleSearch) },
+        onOpenOnlineSearch = {
+          if (subtitlesPreferencesForApiCheck.wyzieApiKey.get().isBlank()) {
+            viewModel.showToast("Wyzie API key not set. Add your key in Settings → Subtitles → Wyzie API Key")
+          } else {
+            onShowSheet(Sheets.OnlineSubtitleSearch)
+          }
+        },
         onDismissRequest = onDismissRequest
       )
     }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SearchablePreference.kt
@@ -450,6 +450,13 @@ object SearchablePreferences {
                 category = "Subtitles",
                 screen = SubtitlesPreferencesScreen,
             ))
+            add(SearchablePreference(
+                titleRes = R.string.pref_wyzie_api_key_title,
+                summaryRes = R.string.pref_wyzie_api_key_summary,
+                keywords = listOf("wyzie", "api", "key", "subtitle", "search", "token", "auth"),
+                category = "Subtitles",
+                screen = SubtitlesPreferencesScreen,
+            ))
 
             // Audio preferences
             add(SearchablePreference(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
@@ -158,6 +158,7 @@ object SubtitlesPreferencesScreen : Screen {
         val wyzieSources by preferences.wyzieSources.collectAsState()
         val wyzieFormats by preferences.wyzieFormats.collectAsState()
         val wyzieEncodings by preferences.wyzieEncodings.collectAsState()
+        val wyzieApiKey by preferences.wyzieApiKey.collectAsState()
 
         val saveLocationPicker =
           rememberLauncherForActivityResult(
@@ -364,6 +365,42 @@ object SubtitlesPreferencesScreen : Screen {
 
           item {
             PreferenceCard {
+              // API Key
+              TextFieldPreference(
+                value = wyzieApiKey,
+                onValueChange = preferences.wyzieApiKey::set,
+                textToValue = { it },
+                title = { Text(stringResource(R.string.pref_wyzie_api_key_title)) },
+                summary = {
+                  if (wyzieApiKey.isNotBlank()) {
+                    Text(
+                      "•".repeat(minOf(wyzieApiKey.length, 16)),
+                      color = MaterialTheme.colorScheme.outline,
+                    )
+                  } else {
+                    Text(
+                      stringResource(R.string.pref_wyzie_api_key_summary),
+                      color = MaterialTheme.colorScheme.outline,
+                    )
+                  }
+                },
+                textField = { value, onValueChange, _ ->
+                  Column {
+                    Text(stringResource(R.string.pref_wyzie_api_key_summary))
+                    Spacer(modifier = Modifier.size(8.dp))
+                    TextField(
+                      value,
+                      onValueChange,
+                      modifier = Modifier.fillMaxWidth(),
+                      placeholder = { Text(stringResource(R.string.pref_wyzie_api_key_placeholder)) },
+                      singleLine = true,
+                    )
+                  }
+                },
+              )
+
+              PreferenceDivider()
+
               // Location display
               Box(
                 modifier = Modifier
@@ -570,12 +607,12 @@ object SubtitlesPreferencesScreen : Screen {
                   color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                  text = "sub.wyzie.ru",
+                  text = "sub.wyzie.io",
                   style = MaterialTheme.typography.bodySmall,
                   color = MaterialTheme.colorScheme.primary,
                   fontWeight = FontWeight.Bold,
                   modifier = Modifier.clickable {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://sub.wyzie.ru"))
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://sub.wyzie.io"))
                     context.startActivity(intent)
                   }
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,9 @@
   <string name="pref_subtitles_clear_downloads_summary">Delete all files in the current save location</string>
   <string name="pref_subtitles_clear_downloads_confirmation">Are you sure you want to delete all downloaded subtitles? This action cannot be undone.</string>
   <string name="toast_subtitles_cleared">Subtitle downloads cleared</string>
+  <string name="pref_wyzie_api_key_title">Wyzie API Key</string>
+  <string name="pref_wyzie_api_key_summary">Required to use sub.wyzie.io subtitle search. Get a free key at sub.wyzie.io/redeem</string>
+  <string name="pref_wyzie_api_key_placeholder">wyzie-abc123xyz</string>
   <string name="pref_audio">Audio</string>
   <string name="pref_audio_summary">Preferred languages, audio channels, pitch correction</string>
   <string name="pref_audio_pitch_correction_title">Enable audio pitch correction</string>


### PR DESCRIPTION
- Migrate base URL from sub.wyzie.ru to sub.wyzie.io

- Add wyzieApiKey preference (Settings → Subtitles → Wyzie API Key)

- Append &key=... to all Wyzie API requests (search, TMDB, TV details)

- Block online subtitle search sheet from opening when key is not set

- Show friendly toast when API key is missing or invalid (401/403)

- Add Wyzie API Key to settings search index